### PR TITLE
+3 Ar 3-21-2018 Optional admin prefix Variable Supported and +4 Ar 3-21-2018 Removed Columns 'Priority' and 'Dead' 

### DIFF
--- a/public/c1.js
+++ b/public/c1.js
@@ -100,7 +100,7 @@
     table7.MakeCellsEditable({
         "onUpdate": table7cb,
         "inputCss":'',
-        "columns": [4,5,6,7],
+        "columns": [4,5],
         "allowNulls": {
         },
         "confirmationButton": { 
@@ -110,30 +110,17 @@
 		"inputTypes":
                 [
 
+
                    {
-                      "column":4, 
-                      "type": "list",
-                      "options":
-                       [
-                          { "value": "TRUE", "display": "TRUE" },
-                          { "value": "FALSE", "display": "FALSE" }
-                       ]
-                   },
-                   {
-				"column":5, 
+				"column":4, 
 				"type":"number",
                                 "step":"0.000000001", 
 				"options":null 
                    }, 
                    {
-				"column":6, 
+				"column":5, 
 				"type":"number", 
                                 "step":"0.000000001", 
-				"options":null 
-                   }, 
-                   {
-				"column":7, 
-				"type":"number", 
 				"options":null 
                    }
 

--- a/src/App.js
+++ b/src/App.js
@@ -8,21 +8,24 @@ class App extends Component {
     super();
     this.state = {
       records: []
-    }
+    };
   }
+
+
 
   //better not to use componentWillMount in general, including for fetching data
   //instead prefer to use componentDidMount() 
   //1-27-2018 iremaka
   componentDidMount() {
 
+        const optz = process.env.REACT_APP_OPTIONAL_ADMIN_PREFIX ? process.env.REACT_APP_OPTIONAL_ADMIN_PREFIX : "";
 
         //created 1-27-2018 iremaka (begin)
 	var head = document.getElementsByTagName('head')[0];
 	(function() {
 		var css = [
-			'/css/font-awesome.min.css',
-                        '/css/jquery.contextMenu.min.css'
+			optz + '/css/font-awesome.min.css',
+                        optz + '/css/jquery.contextMenu.min.css'
 		],
 		i = 0,
 		link = document.createElement('link'),
@@ -39,21 +42,21 @@ class App extends Component {
 
         const script1 = document.createElement("script");
 
-        script1.src = "/datatables.min.js";
+        script1.src = optz + "/datatables.min.js";
         script1.async = false;
 
         document.body.appendChild(script1);
 
         const script1b = document.createElement("script");
 
-        script1b.src = "/jQuery.contextmenu.js";
+        script1b.src = optz + "/jQuery.contextmenu.js";
         script1b.async = false;
 
         document.body.appendChild(script1b);
 
         const script1c = document.createElement("script");
 
-        script1c.src = "/jquery.ui.position.js";
+        script1c.src = optz + "/jquery.ui.position.js";
         script1c.async = false;
 
         document.body.appendChild(script1c);
@@ -78,6 +81,10 @@ class App extends Component {
   //1-27-2018 iremaka (begin)
   componentDidUpdate(prevProps, prevState)
   { 
+
+    const optz = process.env.REACT_APP_OPTIONAL_ADMIN_PREFIX ? process.env.REACT_APP_OPTIONAL_ADMIN_PREFIX : "";
+
+
     /*console.log("prevProps"); 
     console.log(prevProps); 
     console.log("prevState"); 
@@ -88,7 +95,7 @@ class App extends Component {
     {
         const script2 = document.createElement("script");
 
-        script2.src = "/c1.js";
+        script2.src = optz + "/c1.js";
         script2.async = false;
 
         document.body.appendChild(script2);

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -27,10 +27,8 @@ class Dashboard extends Component {
               <th>Created On</th>
               <th>Updated On</th>
               <th>User ID</th>
-              <th data-api="priority">Priority</th>
               <th data-api="lon">Lon</th>
               <th data-api="lat">Lat</th>
-              <th data-api="dead">Dead</th>
               <th>Actions</th>
             </tr>
           </thead>

--- a/src/components/Record/Record.js
+++ b/src/components/Record/Record.js
@@ -25,10 +25,8 @@ class Record extends Component {
         <td>{(this.props.record.time_created === null) ? 'None' : moment(this.props.record.time_created).format('YYYY-MM-DD hh:mm a')}</td>
         <td>{(this.props.record.time_updated === null) ? 'None' : moment(this.props.record.time_updated).format('YYYY-MM-DD hh:mm a')}</td>
         <td>{this.props.record.user_id}</td>
-        <td>{this.props.record.priority ? this.props.record.priority.toString() : this.props.record.priority }</td>
         <td>{this.props.record.lon}</td>
         <td>{this.props.record.lat}</td>
-        <td>{this.props.record.dead}</td>
         <td>
            <Button color="primary" className="context-menu-one">Actions</Button>
         </td>


### PR DESCRIPTION
# +3 Ar 3-21-2018 Optional admin prefix Variable Supported 

The feature Supported in react-scripts@0.5.0 or higher (current is
react-scripts@1.0.17). How it works is the default is empty string if
you don't need this modification for the admin panel, so for deployment
which do not need a prefix for js and css resources in admin panel,
simply leave this alone and don't make use of this option. However, now
supported is the following option: to put a optional admin prefix for js
and css resources duch as "/admin" for certain nginx configurations, how
you do it is at the project root, create a file called ".env" Within the
file called .env what you should do is place this line:
REACT_APP_OPTIONAL_ADMIN_PREFIX=/admin and then after that save the .env
file - after that you should restart the react app server. Now the js
and css resources will come from /admin if you need it.

Note the repeated use of the const optz declaration - because did not want to create a class or global variable, or include react-global type modules since it is not needed - therefore the declaration is repeated to keep it only within the scopes needed. If desired a higher order provider component could be used instead, but this could still expose the optz variable to more scope than needed possibly and may be somewhat  less simple than the chosen solution here.

AND

# +4 Ar 3-21-2018 Removed Columns 'Priority' and 'Dead
+4 Ar 3-21-2018 Removed Columns 'Priority' and 'Dead'
This PR removes the columns 'Priority' and 'Dead' from the admin
interface.