### PR TITLE
Add counter for trees to verify

### DIFF
--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -296,7 +296,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
                       paddingTop: 20
                     }}
                   >
-                    trees to verify
+                  {props.verityState.treeImages.length} trees to verify
                   </Typography>
                 </Grid>
                 <Grid item>
@@ -444,7 +444,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
           <div></div>
         </Modal>
       )}
-      {!props.verityState.isApproveAllProcessing && !props.verityState.isRejectAllProcessing && 
+      {!props.verityState.isApproveAllProcessing && !props.verityState.isRejectAllProcessing &&
         props.verityState.treeImagesUndo.length > 0 && (
           <Snackbar
             open
@@ -455,7 +455,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
             }}
             message={
               <span id='snackbar-fab-message-id'>
-                You have { props.verityState.isBulkApproving ? ' approved ' : ' rejected '}  
+                You have { props.verityState.isBulkApproving ? ' approved ' : ' rejected '}
                 {props.verityState.treeImagesUndo.length}{' '}
                 trees
               </span>


### PR DESCRIPTION
Adds a counter before "Trees to Verify". Not sure what a "tree that hasn't been given tags" means exactly but I'll update accordingly if need be. 

- Resolves https://github.com/Greenstand/treetracker-admin/issues/133

![Screen Shot 2020-03-22 at 10 34 07 PM](https://user-images.githubusercontent.com/12023618/77274875-490d0500-6c8d-11ea-8cde-b8eee7b01885.png)
