### PR TITLE
Trees to verify counter V2

### DIFF
--- a/client/src/api/treeTrackerApi.js
+++ b/client/src/api/treeTrackerApi.js
@@ -81,5 +81,9 @@ export default {
     })
       .then(handleResponse)
       .catch(handleError);
+  },
+  getUnverifiedTreeCount() {
+    const query = `${baseUrl}/trees/count?where[approved]=false&where[active]=true`;
+    return fetch(query).then(handleResponse).catch(handleError);
   }
 };

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -139,6 +139,11 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
     setComplete(props.verityState.approveAllComplete);
   }, [props.verityState.approveAllComplete]);
 
+  /* To update unverified tree count */
+  useEffect(() => {
+      props.verityDispatch.getTreeCount();
+  }, [props.verityState.treeImages]);
+
   function handleTreeClick(e, treeId) {
     e.stopPropagation();
     e.preventDefault();
@@ -296,7 +301,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
                       paddingTop: 20
                     }}
                   >
-                    trees to verify
+                  {props.verityState.treeCount} trees to verify
                   </Typography>
                 </Grid>
                 <Grid item>
@@ -444,7 +449,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
           <div></div>
         </Modal>
       )}
-      {!props.verityState.isApproveAllProcessing && !props.verityState.isRejectAllProcessing && 
+      {!props.verityState.isApproveAllProcessing && !props.verityState.isRejectAllProcessing &&
         props.verityState.treeImagesUndo.length > 0 && (
           <Snackbar
             open
@@ -455,7 +460,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
             }}
             message={
               <span id='snackbar-fab-message-id'>
-                You have { props.verityState.isBulkApproving ? ' approved ' : ' rejected '}  
+                You have { props.verityState.isBulkApproving ? ' approved ' : ' rejected '}
                 {props.verityState.treeImagesUndo.length}{' '}
                 trees
               </span>

--- a/client/src/models/verity.js
+++ b/client/src/models/verity.js
@@ -16,8 +16,8 @@ const verity = {
 		 */
 		treeImagesSelected		: [],
 		/*
-		 * this is a tree id, used to assist selecting trees, when click a tree, 
-		 * and press shift to select a range, then, need use this tree id to cal 
+		 * this is a tree id, used to assist selecting trees, when click a tree,
+		 * and press shift to select a range, then, need use this tree id to cal
 		 * the whole range
 		 */
 		treeImageAnchor		: undefined,
@@ -53,6 +53,7 @@ const verity = {
 			approved		: false,
 			active		: true,
 		}),
+    treeCount: 0,
 	},
 	reducers		: {
 		appendTreeImages(state, treeImages){
@@ -109,6 +110,12 @@ const verity = {
 				filter
 			}
 		},
+    setTreeCount(state, treeCount) {
+        return {
+            ...state,
+            treeCount,
+        };
+    },
 		setApproveAllComplete(state, approveAllComplete){
 			return {
 				...state,
@@ -129,8 +136,8 @@ const verity = {
 			const treeImagesSelected		= state.treeImagesSelected.filter(
 				id => id !== treeId
 			)
-      return { 
-				...state, 
+      return {
+				...state,
 				treeImages,
 				treeImagesSelected,
 			}
@@ -143,8 +150,8 @@ const verity = {
 			const treeImagesSelected		= state.treeImagesSelected.filter(
 				id => id !== treeId
 			)
-      return { 
-				...state, 
+      return {
+				...state,
 				treeImages,
 				treeImagesSelected,
 			}
@@ -153,11 +160,11 @@ const verity = {
 			/*
 			 * put the tree back, from undo list, sort by id
 			 */
-			const treeUndo		= state.treeImagesUndo.reduce((a,c) => 
+			const treeUndo		= state.treeImagesUndo.reduce((a,c) =>
 				(c.id === treeId ? c:a))
-			const treeImagesUndo		= state.treeImagesUndo.filter(tree => 
+			const treeImagesUndo		= state.treeImagesUndo.filter(tree =>
 				tree.id !== treeId)
-			const treeImages		= [...state.treeImages, treeUndo].sort((a,b) => 
+			const treeImages		= [...state.treeImages, treeUndo].sort((a,b) =>
 				(a.id - b.id)
 			)
 			return {
@@ -234,7 +241,7 @@ const verity = {
 			const pageParams = {
 				//page: nextPage,
 				//REVISE Fri Aug 16 10:56:34 CST 2019
-				//change the api to use skip parameter directly, because there is a 
+				//change the api to use skip parameter directly, because there is a
 				//bug to use page as param
 				skip		: verityState.treeImages.length,
 				rowsPerPage: verityState.pageSize,
@@ -261,7 +268,7 @@ const verity = {
 			this.setIsBulkRejecting(true);
 			const verityState		= state.verity;
 			const total		= verityState.treeImagesSelected.length;
-			const undo		= verityState.treeImages.filter(tree => 
+			const undo		= verityState.treeImages.filter(tree =>
 				verityState.treeImagesSelected.some(id => id === tree.id)
 			)
 			log.debug('items:%d', verityState.treeImages.length);
@@ -311,7 +318,7 @@ const verity = {
 			this.setIsBulkApproving(true);
 			const verityState		= state.verity;
 			const total		= verityState.treeImagesSelected.length;
-			const undo		= verityState.treeImages.filter(tree => 
+			const undo		= verityState.treeImages.filter(tree =>
 				verityState.treeImagesSelected.some(id => id === tree.id)
 			)
 			log.debug('items:%d', verityState.treeImages.length);
@@ -421,7 +428,7 @@ const verity = {
 				})
 			}else if(isShift){
 				log.debug(
-					'press shift, and there is an anchor:', 
+					'press shift, and there is an anchor:',
 					state.verity.treeImageAnchor
 				)
 				//if no anchor, then, select from beginning
@@ -446,8 +453,8 @@ const verity = {
 						Math.min(indexAnchor, indexCurrent),
 						Math.max(indexAnchor, indexCurrent) + 1,
 					).map(tree => tree.id)
-				log.trace('find range:[%d,%d], selected:%d', 
-					indexAnchor, 
+				log.trace('find range:[%d,%d], selected:%d',
+					indexAnchor,
 					indexCurrent,
 					treeImagesSelected.length,
 				)

--- a/client/src/models/verity.js
+++ b/client/src/models/verity.js
@@ -412,9 +412,9 @@ const verity = {
      * gets and sets count for unverified trees
      */
     async getTreeCount() {
-        const result = await api.getUnverifiedTreeCount();
-        this.setTreeCount(result.count);
-        return true;
+        const result = await api.getUnverifiedTreeCount()
+        this.setTreeCount(result.count)
+        return true
     },
 		/*
 		 * to select trees

--- a/client/src/models/verity.js
+++ b/client/src/models/verity.js
@@ -408,6 +408,14 @@ const verity = {
 			await this.loadMoreTreeImages()
 			//}}}
 		},
+    /*
+     * gets and sets count for unverified trees
+     */
+    async getTreeCount() {
+        const result = await api.getUnverifiedTreeCount();
+        this.setTreeCount(result.count);
+        return true;
+    },
 		/*
 		 * to select trees
 		 * payload:

--- a/client/src/models/verity.test.js
+++ b/client/src/models/verity.test.js
@@ -20,6 +20,9 @@ describe('verity', () => {
 		api.approveTreeImage		= () => Promise.resolve(true);
 		api.rejectTreeImage		= () => Promise.resolve(true);
 		api.undoTreeImage		= () => Promise.resolve(true);
+    api.getUnverifiedTreeCount = () => Promise.resolve({
+      count   : 1
+    });
 	})
 
 	describe('with a default store', () => {
@@ -39,7 +42,7 @@ describe('verity', () => {
 		describe('loadMoreTreeImages() ', () => {
 			//{{{
 			beforeEach(async () => {
-				const result		= await store.dispatch.verity.loadMoreTreeImages() 
+				const result		= await store.dispatch.verity.loadMoreTreeImages()
 				expect(result).toBe(true)
 			})
 
@@ -61,6 +64,17 @@ describe('verity', () => {
 					},
 				})
 			})
+
+      describe('getTreeCount()', () => {
+        beforeEach(async () => {
+          const result    = await store.dispatch.verity.getTreeCount()
+          expect(result).toBe(true)
+        })
+
+        it('getTreeCount should be 1', () => {
+          expect(store.getState().verity.treeCount).toBe(1)
+        })
+      })
 
 			describe('approveTreeImage(1)', () => {
 				//{{{
@@ -239,7 +253,7 @@ describe('verity', () => {
 					beforeEach(async () => {
 						await store.dispatch.verity.approveAll();
 					})
-					
+
 					it('isBulkApproving === true', () => {
 						expect(store.getState().verity.isBulkApproving).toBe(true)
 					})
@@ -273,7 +287,6 @@ describe('verity', () => {
 						it('isBulkApproving === false', () => {
 							expect(store.getState().verity.isBulkApproving).toBe(false)
 						})
-	
 
 						it('tree list order should be correct', () => {
 							expect(store.getState().verity.treeImages.map(tree => tree.id)).toMatchObject(
@@ -321,7 +334,7 @@ describe('verity', () => {
 						it('isBulkRejecting === false', () => {
 							expect(store.getState().verity.isBulkRejecting).toBe(false)
 						})
-	
+
 						it('tree list should restore to 10', () => {
 							expect(store.getState().verity.treeImages).toHaveLength(10)
 						})


### PR DESCRIPTION
Second attempt at trees to verify counter:
- [x] API call to grab number of unverified trees
- [x] updates count when trees get approved/rejected

- resolves https://github.com/Greenstand/treetracker-admin/issues/133

![Screen Shot 2020-04-04 at 6 57 34 PM](https://user-images.githubusercontent.com/12023618/78463050-84a0c980-76a6-11ea-89ba-b03a4eefdad4.png)
