### PR TITLE
Display 4 trees in one row instead of 3

### DIFF
--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -60,8 +60,8 @@ const useStyles = makeStyles(theme => ({
     height: '12rem'
   },
   cardWrapper: {
-    width: '33.33%',
-    minWidth: 300
+    width: '25%',
+    minWidth: 265
   },
   title: {
     padding: theme.spacing(2, 16)


### PR DESCRIPTION
- resolves https://github.com/Greenstand/treetracker-admin/issues/146

![Screen Shot 2020-04-09 at 10 40 23 PM](https://user-images.githubusercontent.com/12023618/78957400-3aa75180-7ab3-11ea-98c0-ef394ea95b8e.png)
