### PR TITLE
fix docker for development 

### DIFF
--- a/dev/compose/docker-compose.yml
+++ b/dev/compose/docker-compose.yml
@@ -13,6 +13,7 @@ services:
      - "3001:3000"
     volumes:
      - ../../client:/opt/admin-web
+    stdin_open: true
   treetracker-admin-api:
     container_name: "treetracker-admin-api"
     image: "treetracker-admin-api:latest"


### PR DESCRIPTION
- fixes https://github.com/Greenstand/treetracker-admin/issues/174

Docker initially wasn't working for me but I was able to find this github issue (https://github.com/facebook/create-react-app/issues/8688) that listed the following:

> Adding `stdin_open: true` to the docker-compose file solved the issue for me

It seems like a recent update to `react-scripts` has caused Docker to fail for many others and I think because we updated `package.json` in our latest merged in code it caused us to update `react-scripts` as well. 

> Adding `stdin_open: true` or `tty: true` to the docker-compose file works.
> 
> stdin_open stands for interactive and tty means terminal. If you do a quick google search you find this:
> <img alt="Screen Shot 2020-03-24 at 11 22 29" width="765" src="https://user-images.githubusercontent.com/42934458/77415199-655e8e00-6dc2-11ea-86d2-4982cbdc6dfd.png">
> 
> [7e6d6cd](https://github.com/facebook/create-react-app/commit/7e6d6cd05f3054723c8b015c813e13761659759e) clearly indicates a check for interactivity.
> 
> docker run by default allocates tty. So that's why that works.
> https://docs.docker.com/compose/reference/run/
> 
> Docker's documentation says: "For interactive processes (like a shell), you must use -i -t together in order to allocate a tty for the container process."
> 
> https://docs.docker.com/engine/reference/run/#foreground

Would like for others to test before & after to see if this PR fixes the docker issue for them as well!
