### PR TITLE
Fix Menu Bug [75%]

### DIFF
--- a/client/src/components/Filter.js
+++ b/client/src/components/Filter.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Drawer from '@material-ui/core/Drawer';
-import { withStyles } from '@material-ui/styles';
+import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
 import Button from '@material-ui/core/Button';

--- a/client/src/components/IconLogo.js
+++ b/client/src/components/IconLogo.js
@@ -5,10 +5,11 @@ import React		from 'react'
 
 export default function IconLogo(){
 	return (
-		<img 
+		<img
 			style={{
 				maxWidth		: 149,
 				maxHeight		: 32,
+        verticalAlign: 'middle'
 			}}
 			src={require('./images/logo.png')} />
 	)

--- a/client/src/components/MainFrame.js
+++ b/client/src/components/MainFrame.js
@@ -3,10 +3,13 @@
  */
 import React		from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import { useTheme }   from '@material-ui/styles';
+import AppBar from '@material-ui/core/AppBar';
 import Menu		from './common/Menu';
 import Filter		from './Filter';
 import Grid		from '@material-ui/core/Grid';
 import Box		from '@material-ui/core/Box';
+import MenuIcon from '@material-ui/icons/Menu';
 import Table		from '@material-ui/core/Table';
 import TableHead		from '@material-ui/core/TableHead';
 import TableRow		from '@material-ui/core/TableRow';
@@ -15,6 +18,8 @@ import TableBody		from '@material-ui/core/TableBody';
 import TextField		from '@material-ui/core/TextField';
 import TableFooter		from '@material-ui/core/TableFooter';
 import TablePagination		from '@material-ui/core/TablePagination';
+import IconButton from '@material-ui/core/IconButton';
+import IconFilter from '@material-ui/icons/FilterList';
 import IconSettings		from '@material-ui/icons/Settings';
 import IconSearch		from '@material-ui/icons/Search';
 import InputAdornment		from '@material-ui/core/InputAdornment';
@@ -22,18 +27,27 @@ import IconCloudDownload		from '@material-ui/icons/CloudDownload';
 import FilterModel		from '../models/Filter';
 import Typography		from '@material-ui/core/Typography';
 import TreeImageScrubber		from './TreeImageScrubber';
+import FilterTop from './FilterTop';
+import IconLogo   from './IconLogo';
 import Trees		from './Trees';
+
+const SIDE_PANEL_WIDTH = 315;
 
 const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
-    marginTop: theme.spacing(3),
+    // marginTop: theme.spacing(3),
     overflowX: 'auto',
   },
   table: {
     minWidth: 650,
 		width		: 724,
   },
+  appBar: {
+    width: `calc(100% - ${SIDE_PANEL_WIDTH}px)`,
+    left: 0,
+    right: 'auto',
+  }
 }));
 
 function createData(name, calories, fat, carbs, protein) {
@@ -47,8 +61,9 @@ const rows = [
   createData('Cupcake', 305, 3.7, 67, 4.3),
   createData('Gingerbread', 356, 16.0, 49, 3.9),
 ];
+
 function SimpleTable() {
-  const classes = useStyles();
+  const classes = useStyles()
 
   return (
       <Table className={classes.table}>
@@ -63,7 +78,7 @@ function SimpleTable() {
         </TableHead>
         <TableBody>
           {rows.map(row => (
-            <TableRow 
+            <TableRow
 							key={row.name}
 							hover={true}
 						>
@@ -93,30 +108,84 @@ function SimpleTable() {
       </Table>
   );
 }
+
 export default function(){
+  const classes = useStyles()
 	const [menuName, setMenuName]		= React.useState(/* default menu */'Verify')
+  const [isFilterShown, setFilterShown] = React.useState(false)
+  const [isMenuShown, setMenuShown] = React.useState(false)
 	const refContainer		= React.useRef()
 
 	function handleMenuClick(menuName){
 		setMenuName(menuName)
+    setMenuShown(false)
 	}
 
+  function handleToggleMenu(){
+    setMenuShown(!isMenuShown)
+  }
+
+  function handleFilterClick() {
+    if (isFilterShown) {
+      setFilterShown(false);
+    } else {
+      setFilterShown(true);
+    }
+  }
+
 	return(
-		<Grid container wrap='nowrap' >
+		<Grid container wrap='nowrap'>
 			<Grid item>
-        {/* hide menu 
-				<Menu
-					active={menuName}
-					onClick={handleMenuClick}
-				/>
-        */}
-			</Grid>
+        <AppBar
+          color='default'
+          className={classes.appBar}
+        >
+          <Grid container direction='column'>
+            <Grid item>
+              <Grid container justify='space-between'>
+                <Grid item>
+                  <IconButton onClick={handleToggleMenu}>
+                    <MenuIcon/>
+                  </IconButton>
+                  <IconLogo/>
+                </Grid>
+                <Grid item>
+                  <IconButton
+                    onClick={handleFilterClick}
+                  >
+                    <IconFilter />
+                  </IconButton>
+                </Grid>
+              </Grid>
+            </Grid>
+            {/*isFilterShown &&
+            <Grid item>
+              <FilterTop
+                isOpen={isFilterShown}
+                onSubmit={filter => {
+                  props.verityDispatch.updateFilter(filter);
+                }}
+                filter={props.verityState.filter}
+                onClose={handleFilterClick}
+              />
+            </Grid>
+            */}
+          </Grid>
+        </AppBar>
+      </Grid>
+      {isMenuShown &&
+        <Menu
+          active={menuName}
+          onClick={handleMenuClick}
+          onClose={() => setMenuShown(false)}
+        />
+      }
 			<Grid item
 				style={{
 					width		: '100%',
 				}}
 			>
-				<Grid 
+				<Grid
 					container
 					ref={refContainer}
 					style={{
@@ -137,9 +206,9 @@ export default function(){
 							>
 								<Typography variant='h5' >2,000 trees</Typography>
 								<Box py={2}>
-									<Grid 
-										container 
-										justify='space-between' 
+									<Grid
+										container
+										justify='space-between'
 										alignItems='center'
 									>
 										<Grid item>

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -47,8 +47,6 @@ import FilterModel from '../models/Filter';
 import { ReactComponent as TreePin } from '../components/images/highlightedPinNoStick.svg';
 import IconLogo		from './IconLogo';
 import Menu from './common/Menu.js';
-import CheckIcon from '@material-ui/icons/Check';
-import Paper from '@material-ui/core/Paper';
 
 const log = require('loglevel').getLogger('../components/TreeImageScrubber');
 
@@ -71,17 +69,6 @@ const useStyles = makeStyles(theme => ({
   card: {
     cursor: 'pointer',
     margin: '0.5rem'
-  },
-  cardCheckbox: {
-    position: 'absolute',
-    height: '1.2em',
-    width: '1.2em',
-    top: '0.2rem',
-    left: '0.3rem',
-    pointerEvents: 'none',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center'
   },
   cardSelected: {
     backgroundColor: theme.palette.action.selected
@@ -107,7 +94,6 @@ const useStyles = makeStyles(theme => ({
         duration: '0.3s'
       }),
     },
-    position: 'relative',
     width: '30%',
     minWidth: 300,
     margin: 2
@@ -311,29 +297,17 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
     })
   }
 
-  function isTreeSelected(id){
-    return props.verityState.treeImagesSelected.indexOf(id) >= 0
-  }
-
   let treeImageItems = props.verityState.treeImages.map(tree => {
     if (tree.imageUrl) {
       return (
         <div
           className={clsx(
             classes.cardWrapper,
-            isTreeSelected(tree.id)
+            props.verityState.treeImagesSelected.indexOf(tree.id) >= 0
               ? classes.cardSelected
               : undefined
           )} key={tree.id}
         >
-          {isTreeSelected(tree.id) &&
-            (<Paper
-              className={classes.cardCheckbox}
-              elevation={4}
-            >
-              <CheckIcon/>
-            </Paper>)
-          }
           <Card
             onClick={e => handleTreeClick(e, tree.id)}
             id={`card_${tree.id}`}
@@ -344,7 +318,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
               <CardMedia className={classes.cardMedia} image={tree.imageUrl} />
             </CardContent>
             <CardActions className={classes.cardActions}>
-              <Grid 
+              <Grid
                 justify='flex-end'
                 container>
                 <Grid item>
@@ -383,10 +357,11 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
 
   return (
     <React.Fragment>
-      <Grid 
+      <Grid
         container
         direction='column'
       >
+      {/*
         <Grid item>
           <AppBar
             color='default'
@@ -396,8 +371,8 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
               <Grid item>
                 <Grid container justify='space-between'>
                   <Grid item>
-                    <IconButton onClick={handleToggleMenu}>
-                      <MenuIcon/>
+                    <IconButton>
+                      <MenuIcon onClick={handleToggleMenu}/>
                     </IconButton>
                     <IconLogo/>
                   </Grid>
@@ -425,8 +400,9 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
             </Grid>
           </AppBar>
         </Grid>
-        <Grid 
-          item 
+      */}
+        <Grid
+          item
           className={classes.body}
           style={{
             marginTop: isFilterShown? 100:50,
@@ -472,11 +448,11 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
       <SidePanel
         onSubmit={handleSubmit}
       />
-      {isMenuShown &&
+      {/*isMenuShown &&
         <Menu
           onClose={() => setMenuShown(false)}
         />
-      }
+      */}
       {props.verityState.isApproveAllProcessing && (
         <AppBar
           position='fixed'
@@ -540,12 +516,12 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
           <Grid container justify="space-between" >
             <Grid item>
               <Typography variant='body2' color="primary" gutterBottom>
-                Tree #{dialog.tree.id}, 
-                Planter #{dialog.tree.planterId}, 
+                Tree #{dialog.tree.id},
+                Planter #{dialog.tree.planterId},
                 Device #{dialog.tree.deviceId}
               </Typography>
               <Typography variant='body2' color="primary" gutterBottom>
-                Created time: {dialog.tree.timeCreated}, 
+                Created time: {dialog.tree.timeCreated},
               </Typography>
             </Grid>
             <Grid item>
@@ -599,27 +575,27 @@ function SidePanel(props){
         </Grid>
         <Grid className={`${classes.bottomLine} ${classes.sidePanelItem}`}>
           <RadioGroup value={morphology} className={classes.radioGroup}>
-            <FormControlLabel 
-              value='seedling' 
-              onClick={() => handleMorphology('seedling')} 
-              control={<Radio/>} 
+            <FormControlLabel
+              value='seedling'
+              onClick={() => handleMorphology('seedling')}
+              control={<Radio/>}
               label='Seedling' />
-            <FormControlLabel 
-              value='direct_seedling' 
-              control={<Radio/>} 
+            <FormControlLabel
+              value='direct_seedling'
+              control={<Radio/>}
               onClick={() => handleMorphology('direct_seedling')}
               label='Direct seeding' />
-            <FormControlLabel 
+            <FormControlLabel
               onClick={() => handleMorphology('fmnr')}
               value='fmnr' control={<Radio/>} label='Pruned/tied(FMNR)' />
           </RadioGroup>
         </Grid>
         <Grid className={`${classes.bottomLine} ${classes.sidePanelItem}`}>
           <RadioGroup value={age} className={classes.radioGroup}>
-            <FormControlLabel 
+            <FormControlLabel
               onClick={() => handleAge('new_tree')}
               value='new_tree' control={<Radio/>} label='New tree(s)' />
-            <FormControlLabel 
+            <FormControlLabel
               onClick={() => handleAge('over_two_years')}
               value='over_two_years' control={<Radio/>} label='> 2 years old' />
           </RadioGroup>
@@ -639,18 +615,18 @@ function SidePanel(props){
           />
         </Grid>
         <Grid className={`${classes.bottomLine} ${classes.sidePanelItem}`}>
-          <Tabs 
+          <Tabs
             indicatorColor='primary'
             textColor='primary'
             variant='fullWidth'
             value={switchApprove}
           >
-            <Tab label='APPROVE' 
+            <Tab label='APPROVE'
               id='full-width-tab-0'
               aria-controls='full-width-tabpanel-0'
               onClick={() => handleSwitchApprove(0)}
             />
-            <Tab 
+            <Tab
               label='REJECT'
               id='full-width-tab-0'
               aria-controls='full-width-tabpanel-0'
@@ -661,28 +637,28 @@ function SidePanel(props){
             <RadioGroup
               value={captureApprovalTag}
             >
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('simple_lead')}
                 value='simple_lead' control={<Radio/>} label='Simple leaf' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('complex_leaf')}
                 value='complex_leaf' control={<Radio/>} label='Complex leaf' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('acacia_like')}
                 value='acacia_like' control={<Radio/>} label='Acacia-like' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('conifer')}
                 value='conifer' control={<Radio/>} label='Conifer' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('fruit')}
                 value='fruit' control={<Radio/>} label='Fruit' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('mangrove')}
                 value='mangrove' control={<Radio/>} label='Mangrove' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('plam')}
                 value='plam' control={<Radio/>} label='Palm' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('timber')}
                 value='timber' control={<Radio/>} label='Timber' />
             </RadioGroup>
@@ -691,30 +667,30 @@ function SidePanel(props){
             <RadioGroup
               value={rejectionReason}
             >
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleRejectionReason('not_tree')}
                 value='not_tree' control={<Radio/>} label='Not a tree' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleRejectionReason('unapproved_tree')}
                 value='unapproved_tree' control={<Radio/>} label='Not an approved tree' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('blurry_image')}
                 value='blurry_image' control={<Radio/>} label='Blurry photo' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('dead')}
                 value='dead' control={<Radio/>} label='Dead' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('duplicate_image')}
                 value='duplicate_image' control={<Radio/>} label='Duplicate photo' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('flag_user')}
                 value='flag_user' control={<Radio/>} label='Flag user!' />
-              <FormControlLabel 
+              <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('needs_contact_or_review')}
                 value='needs_contact_or_review' control={<Radio/>} label='Flag tree for contact/review' />
             </RadioGroup>
           }
-        
+
         </Grid>
         <Grid className={`${classes.sidePanelItem}`}>
           <TextField placeholder='Note(optional)' ></TextField>

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -45,8 +45,10 @@ import FilterTop from './FilterTop';
 import { MENU_WIDTH } from './common/Menu';
 import FilterModel from '../models/Filter';
 import { ReactComponent as TreePin } from '../components/images/highlightedPinNoStick.svg';
-import IconLogo		from './IconLogo';
+import IconLogo   from './IconLogo';
 import Menu from './common/Menu.js';
+import CheckIcon from '@material-ui/icons/Check';
+import Paper from '@material-ui/core/Paper';
 
 const log = require('loglevel').getLogger('../components/TreeImageScrubber');
 
@@ -69,6 +71,17 @@ const useStyles = makeStyles(theme => ({
   card: {
     cursor: 'pointer',
     margin: '0.5rem'
+  },
+  cardCheckbox: {
+    position: 'absolute',
+    height: '1.2em',
+    width: '1.2em',
+    top: '0.2rem',
+    left: '0.3rem',
+    pointerEvents: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
   },
   cardSelected: {
     backgroundColor: theme.palette.action.selected
@@ -94,6 +107,7 @@ const useStyles = makeStyles(theme => ({
         duration: '0.3s'
       }),
     },
+    position: 'relative',
     width: '30%',
     minWidth: 300,
     margin: 2
@@ -297,17 +311,29 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
     })
   }
 
+  function isTreeSelected(id){
+    return props.verityState.treeImagesSelected.indexOf(id) >= 0
+  }
+
   let treeImageItems = props.verityState.treeImages.map(tree => {
     if (tree.imageUrl) {
       return (
         <div
           className={clsx(
             classes.cardWrapper,
-            props.verityState.treeImagesSelected.indexOf(tree.id) >= 0
+            isTreeSelected(tree.id)
               ? classes.cardSelected
               : undefined
           )} key={tree.id}
         >
+          {isTreeSelected(tree.id) &&
+            (<Paper
+              className={classes.cardCheckbox}
+              elevation={4}
+            >
+              <CheckIcon/>
+            </Paper>)
+          }
           <Card
             onClick={e => handleTreeClick(e, tree.id)}
             id={`card_${tree.id}`}
@@ -361,7 +387,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
         container
         direction='column'
       >
-      {/*
+        { /*
         <Grid item>
           <AppBar
             color='default'
@@ -371,8 +397,8 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
               <Grid item>
                 <Grid container justify='space-between'>
                   <Grid item>
-                    <IconButton>
-                      <MenuIcon onClick={handleToggleMenu}/>
+                    <IconButton onClick={handleToggleMenu}>
+                      <MenuIcon/>
                     </IconButton>
                     <IconLogo/>
                   </Grid>
@@ -400,7 +426,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
             </Grid>
           </AppBar>
         </Grid>
-      */}
+        */}
         <Grid
           item
           className={classes.body}
@@ -448,11 +474,11 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
       <SidePanel
         onSubmit={handleSubmit}
       />
-      {/*isMenuShown &&
+      {isMenuShown &&
         <Menu
           onClose={() => setMenuShown(false)}
         />
-      */}
+      }
       {props.verityState.isApproveAllProcessing && (
         <AppBar
           position='fixed'

--- a/client/src/components/TreeTable.js
+++ b/client/src/components/TreeTable.js
@@ -21,7 +21,7 @@ const styles = () => ({
     overflowX: 'auto',
   },
 	myTable		: {
-		width		: `calc(100vw - ${MENU_WIDTH}px - ${FILTER_WIDTH}px)`,
+		width		: `calc(100vw - ${FILTER_WIDTH}px)`,
 	},
   locationCol: {
     width: '270px'
@@ -143,8 +143,8 @@ class TreeTable extends Component {
 				name		: 'status',
 				label		: 'Status',
 			},
-      { 
-				name: 'timeCreated', 
+      {
+				name: 'timeCreated',
 				label: 'Created',
 				options		: {
 					customBodyRender		: v => `${dateformat(v, 'm/d/yyyy h:Mtt')}`,
@@ -194,8 +194,8 @@ class TreeTable extends Component {
         >
           <TreeDetails tree={tree} />
         </Drawer>
-				<Filter 
-					isOpen={true} 
+				<Filter
+					isOpen={true}
 					onSubmit={this.handleFilterSubmit}
 					filter={this.state.filter}
 				/>

--- a/client/src/components/common/Menu.js
+++ b/client/src/components/common/Menu.js
@@ -109,6 +109,7 @@ export default function GSMenu(props){
 				<Box height={20} />
 				{menus.map(item => (
 					<MenuItem
+            key={item.name}
 						className={classes.menuItem}
 						selected={props.active === item.name}
 						onClick={() => props.onClick(item.name)}


### PR DESCRIPTION
- resolves https://github.com/Greenstand/treetracker-admin/issues/166
- resolves https://github.com/Greenstand/treetracker-admin/issues/179

Managed to fix the Menu so that one can toggle between the `Verify` and `Trees` but right now the Filter toggle button doesn't work (since it is specific to the `<TreeImageScrubber>` component). Trying to figure out a way to show/get working the filter toggle only on the menu for the Verify page. Any advice on solving this from those more experienced with React would be greatly appreciated!

![Screen Shot 2020-05-15 at 11 17 32 PM](https://user-images.githubusercontent.com/12023618/82109292-b32cae00-9702-11ea-8db0-b2a201904690.png)
![Screen Shot 2020-05-15 at 11 17 47 PM](https://user-images.githubusercontent.com/12023618/82109293-b9bb2580-9702-11ea-97ca-e093013ec4f2.png)
