### PR TITLE
Rearranged grid to fix scrollbars

### DIFF
--- a/client/src/components/MainFrame.js
+++ b/client/src/components/MainFrame.js
@@ -95,7 +95,6 @@ function SimpleTable() {
 }
 export default function(){
 	const [menuName, setMenuName]		= React.useState(/* default menu */'Verify')
-	const refContainer		= React.useRef()
 
 	function handleMenuClick(menuName){
 		setMenuName(menuName)
@@ -118,7 +117,6 @@ export default function(){
 			>
 				<Grid 
 					container
-					ref={refContainer}
 					style={{
 						height		: '100vh',
 						overflow		: 'auto',
@@ -181,7 +179,7 @@ export default function(){
 						</React.Fragment>
 					}
 					{menuName === 'Verify' &&
-						<TreeImageScrubber getScrollContainerRef={() => refContainer.current}/>
+						<TreeImageScrubber/>
 					}
 				</Grid>
 			</Grid>

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -121,15 +121,18 @@ const useStyles = makeStyles(theme => ({
     right: 'auto',
   },
   sidePanel: {
+    width: SIDE_PANEL_WIDTH,
   },
   drawerPaper: {
     width: SIDE_PANEL_WIDTH,
   },
   body: {
-    width: `calc(100% - ${SIDE_PANEL_WIDTH}px)`,
+    display: 'flex',
+    height: '100%',
   },
   sidePanelContainer: {
     padding: theme.spacing(2),
+    flexWrap: 'nowrap',
   },
   sidePanelItem: {
     marginTop: theme.spacing(1),
@@ -358,8 +361,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
   return (
     <React.Fragment>
       <Grid 
-        container
-        direction='column'
+        className={classes.body}
       >
         <Grid item>
           <AppBar
@@ -399,11 +401,11 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
             </Grid>
           </AppBar>
         </Grid>
-        <Grid 
-          item 
-          className={classes.body}
+        <Grid
+          item
           style={{
-            marginTop: isFilterShown? 100:50,
+            overflow: 'auto',
+            marginTop: isFilterShown? 156:44,
           }}
         >
           <Grid container>
@@ -442,10 +444,10 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
             </Grid>
           </Grid>
         </Grid>
+        <SidePanel
+          onSubmit={handleSubmit}
+        />
       </Grid>
-      <SidePanel
-        onSubmit={handleSubmit}
-      />
       {isMenuShown &&
         <Menu
           onClose={() => setMenuShown(false)}

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -153,7 +153,7 @@ const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="up" ref={ref} {...props} />;
 });
 
-const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
+const TreeImageScrubber = (props) => {
   log.debug('render TreeImageScrubber...');
   log.debug('complete:', props.verityState.approveAllComplete);
   const classes = useStyles(props);
@@ -161,6 +161,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
   const [isFilterShown, setFilterShown] = React.useState(false);
   const [isMenuShown, setMenuShown] = React.useState(false);
   const [dialog, setDialog] = React.useState({isOpen: false, tree: {}});
+	const refContainer = React.useRef();
 
   /*
    * effect to load page when mounted
@@ -176,7 +177,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
   useEffect(() => {
     log.debug('verity state changed');
     //move add listener to effect to let it refresh at every state change
-    let scrollContainerRef = getScrollContainerRef();
+    let scrollContainerRef = refContainer.current;
     const handleScroll = e => {
       if (
         scrollContainerRef &&
@@ -403,6 +404,7 @@ const TreeImageScrubber = ({ getScrollContainerRef, ...props }) => {
         </Grid>
         <Grid
           item
+					ref={refContainer}
           style={{
             overflow: 'auto',
             marginTop: isFilterShown? 156:44,


### PR DESCRIPTION
Resolves #177 

- Rearranged the grid slightly to closer match the Material UI example at https://material-ui.com/components/drawers/#permanent-drawer.
- Moved scroll handling to `TreeImageScrubber` to keep infinite scroll functionality.

![Greenstand - Tree Tracker - Google Chrome 2020-05-16 14-09-05](https://user-images.githubusercontent.com/5558838/82121143-bff0e680-9782-11ea-9047-959f77984261.gif)

