### PR TITLE
Close Tree Image dialog on click outside dialog

### DIFF
--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -535,6 +535,7 @@ const TreeImageScrubber = (props) => {
       <Dialog
         open={dialog.isOpen}
         TransitionComponent={Transition}
+        onClose={handleDialogClose}
       >
         <DialogTitle>Tree Detail</DialogTitle>
         <DialogContent>


### PR DESCRIPTION
Resolves #203 

Tree Detail dialog now closes when the user clicks outside the dialog, presses _Esc_ or clicks _Close_.