### PR TITLE
Added pagination to the Verify page

### DIFF
--- a/client/src/api/treeTrackerApi.js
+++ b/client/src/api/treeTrackerApi.js
@@ -96,6 +96,10 @@ export default {
     const query = `${process.env.REACT_APP_API_ROOT}/trees/count?where[approved]=false&where[active]=true`;
     return fetch(query).then(handleResponse).catch(handleError);
   },
+  getTreeCount(filter) {
+    const query = `${process.env.REACT_APP_API_ROOT}/trees/count?${filter.getBackloopString(false)}`;
+    return fetch(query).then(handleResponse).catch(handleError);
+  },
   /*
    * get species list
    */

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -49,6 +49,7 @@ import IconLogo		from './IconLogo';
 import Menu from './common/Menu.js';
 import CheckIcon from '@material-ui/icons/Check';
 import Paper from '@material-ui/core/Paper';
+import TablePagination from '@material-ui/core/TablePagination';
 
 const log = require('loglevel').getLogger('../components/TreeImageScrubber');
 
@@ -106,6 +107,15 @@ const useStyles = makeStyles(theme => ({
     }),
     '&:not($cardSelected):hover': {
       padding: 0,
+    },
+  },
+  placeholderCard: {
+    pointerEvents: 'none',
+    '& $card': {
+      background: '#eee',
+      '& *': {
+        opacity: 0,
+      },
     },
   },
   title: {
@@ -171,64 +181,31 @@ const TreeImageScrubber = (props) => {
   const [isFilterShown, setFilterShown] = React.useState(false);
   const [isMenuShown, setMenuShown] = React.useState(false);
   const [dialog, setDialog] = React.useState({isOpen: false, tree: {}});
-	const refContainer = React.useRef();
+  const refContainer = React.useRef();
 
   /*
    * effect to load page when mounted
    */
   useEffect(() => {
     log.debug('mounted');
-    props.verityDispatch.loadMoreTreeImages();
+    props.verityDispatch.loadTreeImages();
   }, []);
-
-  /*
-   * effect to set the scroll event
-   */
-  useEffect(() => {
-    log.debug('verity state changed');
-    //move add listener to effect to let it refresh at every state change
-    let scrollContainerRef = refContainer.current;
-    const handleScroll = e => {
-      if (
-        scrollContainerRef &&
-        Math.floor(scrollContainerRef.scrollTop) !==
-          Math.floor(scrollContainerRef.scrollHeight) -
-            Math.floor(scrollContainerRef.offsetHeight)
-      ) {
-        return;
-      }
-      props.verityDispatch.loadMoreTreeImages();
-    };
-    let isListenerAttached = false;
-    if (
-      scrollContainerRef &&
-      //should not listen scroll when loading
-      !props.verityState.isLoading
-    ) {
-      log.debug('attaching listener');
-      scrollContainerRef.addEventListener('scroll', handleScroll);
-      isListenerAttached = true;
-    } else {
-      log.debug('do not attach listener');
-    }
-
-    return () => {
-      if (isListenerAttached) {
-        scrollContainerRef.removeEventListener('scroll', handleScroll);
-      }
-    };
-  }, [props.verityState]);
 
   /* to display progress */
   useEffect(() => {
     setComplete(props.verityState.approveAllComplete);
   }, [props.verityState.approveAllComplete]);
 
-//  /* To update unverified tree count */
-//  useEffect(() => {
-//      props.verityDispatch.getTreeCount();
-//  }, [props.verityState.treeImages]);
+  /* To update tree count */
+  useEffect(() => {
+    props.verityDispatch.getTreeCount();
+  }, [props.verityState.treeImages]);
 
+  /* load more trees when the page or page size changes */
+  useEffect(() => {
+    props.verityDispatch.loadTreeImages();
+  }, [props.verityState.pageSize, props.verityState.currentPage, props.verityState.filter]);
+  
   function handleTreeClick(e, treeId) {
     e.stopPropagation();
     e.preventDefault();
@@ -281,18 +258,10 @@ const TreeImageScrubber = (props) => {
         console.log('species id:', speciesId)
     }
     const result = await props.verityDispatch.approveAll({approveAction});
-    if (result) {
-      //if all trees were approved, then, load more
-      if (
-        props.verityState.treeImagesSelected.length ===
-        props.verityState.treeImages.length
-      ) {
-        log.debug('all trees approved, reload');
-        props.verityDispatch.loadMoreTreeImages();
-      }
-    } else {
+    if (!result) {
       window.alert('sorry, failed to approve some picture');
     }
+    props.verityDispatch.loadTreeImages();
   }
 
   function handleDialog(e, tree){
@@ -311,12 +280,32 @@ const TreeImageScrubber = (props) => {
     })
   }
 
+  function handleChangePageSize(event, value){
+    props.verityDispatch.set({pageSize: event.target.value});
+  }
+
+  function handleChangePage(event, page){
+    props.verityDispatch.set({currentPage: page});
+  }
+
   function isTreeSelected(id){
     return props.verityState.treeImagesSelected.indexOf(id) >= 0
   }
 
-  let treeImageItems = props.verityState.treeImages.map(tree => {
-    if (tree.imageUrl) {
+  const placeholderImages = Array(props.verityState.pageSize).fill().map((_, index) => {
+    return {
+      id: index,
+      placeholder: true,
+    };
+  });
+
+  const treeImages = props.verityState.treeImages.filter((tree, index) => {
+    return index >= props.verityState.currentPage * props.verityState.pageSize &&
+           index < (props.verityState.currentPage+1) * props.verityState.pageSize;
+  });
+
+  const treeImageItems = (props.verityState.isLoading ? placeholderImages : treeImages)
+    .map(tree => {
       return (
         <Grid item xs={12} sm={6} md={4} xl={3}>
           <div
@@ -324,7 +313,8 @@ const TreeImageScrubber = (props) => {
               classes.cardWrapper,
               isTreeSelected(tree.id)
                 ? classes.cardSelected
-                : undefined
+                : undefined,
+              tree.placeholder && classes.placeholderCard
             )} key={tree.id}
           >
             {isTreeSelected(tree.id) &&
@@ -339,10 +329,10 @@ const TreeImageScrubber = (props) => {
               onClick={e => handleTreeClick(e, tree.id)}
               id={`card_${tree.id}`}
               className={classes.card}
-              elevation={3}
+              elevation={tree.placeholder ? 0 : 3}
             >
               <CardContent className={classes.cardContent}>
-                <CardMedia className={classes.cardMedia} image={tree.imageUrl} />
+                {tree.imageUrl && <CardMedia className={classes.cardMedia} image={tree.imageUrl} />}
               </CardContent>
               <CardActions className={classes.cardActions}>
                 <Grid 
@@ -369,7 +359,7 @@ const TreeImageScrubber = (props) => {
         </Grid>
       );
     }
-  });
+  );
 
   function handleFilterClick() {
     if (isFilterShown) {
@@ -382,6 +372,19 @@ const TreeImageScrubber = (props) => {
   function handleToggleMenu(){
     setMenuShown(!isMenuShown)
   }
+
+  let imagePagination = (
+    <TablePagination
+      rowsPerPageOptions={[12, 24, 48, 96]}
+      component="div"
+      count={props.verityState.treeCount}
+      rowsPerPage={props.verityState.pageSize}
+      page={props.verityState.currentPage}
+      onChangePage={handleChangePage}
+      onChangeRowsPerPage={handleChangePageSize}
+      labelRowsPerPage="Images per page:"
+    />
+  );
 
   return (
     <React.Fragment>
@@ -443,20 +446,17 @@ const TreeImageScrubber = (props) => {
             >
               <Grid
                 container
-                justify={'space-between'}
+                justify='space-between'
+                alignItems='center'
                 className={classes.title}
               >
                 <Grid item>
-                  <Typography
-                    variant='h5'
-                    style={{
-                      paddingTop: 20
-                    }}
-                  >
+                  <Typography variant='h5'>
                   {false /* close counter*/&& props.verityState.treeCount} trees to verify
                   </Typography>
                 </Grid>
                 <Grid item>
+                  {imagePagination}
                 </Grid>
               </Grid>
             </Grid>
@@ -467,6 +467,9 @@ const TreeImageScrubber = (props) => {
               }}
             >
               <Grid container className={classes.wrapper} spacing={1}>{treeImageItems}</Grid>
+            </Grid>
+            <Grid item container justify='flex-end' className={classes.title}>
+              {imagePagination}
             </Grid>
           </Grid>
         </Grid>

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -204,7 +204,7 @@ const TreeImageScrubber = (props) => {
   /* load more trees when the page or page size changes */
   useEffect(() => {
     props.verityDispatch.loadTreeImages();
-  }, [props.verityState.pageSize, props.verityState.currentPage, props.verityState.filter]);
+  }, [props.verityState.pageSize, props.verityState.currentPage]);
   
   function handleTreeClick(e, treeId) {
     e.stopPropagation();

--- a/client/src/models/Filter.js
+++ b/client/src/models/Filter.js
@@ -18,48 +18,49 @@ export default class Filter{
 		Object.assign(this, options)
 	}
 
-	getBackloopString(){
+	getBackloopString(includeFilterString=true){
 		//{{{
 		let result		= ''
+		const prefix = includeFilterString ? '&filter[where]' : '&where'
 
 		if(this.treeId){
-			result		+= `&filter[where][id]=${this.treeId}`
+			result		+= `${prefix}[id]=${this.treeId}`
 		}
 
 		if(this.status){
-			result		+= `&filter[where][status]=${this.status.toLowerCase()}`
+			result		+= `${prefix}[status]=${this.status.toLowerCase()}`
 		}
 
 		if(this.dateStart && this.dateEnd){
-			result		+= `&filter[where][timeCreated][between]=${this.dateStart}&filter[where][timeCreated][between]=${this.dateEnd}`
+			result		+= `${prefix}[timeCreated][between]=${this.dateStart}${prefix}[timeCreated][between]=${this.dateEnd}`
 		}else if(this.dateStart && !this.dateEnd){
-			result		+= `&filter[where][timeCreated][gte]=${this.dateStart}`
+			result		+= `${prefix}[timeCreated][gte]=${this.dateStart}`
 		}else if(!this.dateStart && this.dateEnd){
-			result		+= `&filter[where][timeCreated][lte]=${this.dateEnd}`
+			result		+= `${prefix}[timeCreated][lte]=${this.dateEnd}`
 		}
 
 		if(this.approved !== undefined){
-			result		+= `&filter[where][approved]=${this.approved}`
+			result		+= `${prefix}[approved]=${this.approved}`
 		}
 
 		if(this.active !== undefined){
-			result		+= `&filter[where][active]=${this.active}`
+			result		+= `${prefix}[active]=${this.active}`
 		}
 
 		if(this.planterId !== undefined && this.planterId.length > 0){
-			result		+= `&filter[where][planterId]=${this.planterId}`
+			result		+= `${prefix}[planterId]=${this.planterId}`
 		}
 
 		if(this.deviceId !== undefined && this.deviceId.length > 0){
-			result		+= `&filter[where][deviceId]=${this.deviceId}`
+			result		+= `${prefix}[deviceId]=${this.deviceId}`
 		}
 
 		if(this.planterIdentifier !== undefined && this.planterIdentifier.length > 0){
-			result		+= `&filter[where][planterIdentifier]=${this.planterIdentifier}`
+			result		+= `${prefix}[planterIdentifier]=${this.planterIdentifier}`
 		}
 
     if(this.speciesId){
-			result		+= `&filter[where][speciesId]=${this.speciesId}`
+			result		+= `${prefix}[speciesId]=${this.speciesId}`
     }
 
 		return result

--- a/client/src/models/Filter.test.js
+++ b/client/src/models/Filter.test.js
@@ -23,6 +23,13 @@ describe('Filter, with initial values about this filter object', () => {
 		expect(filter.getBackloopString().indexOf('&filter[where][timeCreated][between]=2019-07-25&filter[where][timeCreated][between]=2019-07-30') >=0).toBe(true)
 	})
 
+	it('getBackloopString(false) should be: ', () => {
+		console.log(filter.getBackloopString(false))
+		expect(filter.getBackloopString(false).indexOf('&where[id]=10') >= 0).toBe(true)
+		expect(filter.getBackloopString(false).indexOf('&where[status]=planted') >=0).toBe(true)
+		expect(filter.getBackloopString(false).indexOf('&where[timeCreated][between]=2019-07-25&where[timeCreated][between]=2019-07-30') >=0).toBe(true)
+	})
+
 	it('getBackloopString() should match: approved=true', () => {
 		expect(filter.getBackloopString().indexOf('&filter[where][approved]=true') >= 0).toBe(true)
 	})

--- a/client/src/models/verity.js
+++ b/client/src/models/verity.js
@@ -270,7 +270,7 @@ const verity = {
 			log.debug('to load images')
 			const verityState		= state.verity
 			if (verityState.isLoading ||
-					verityState.treeImages.length >= verityState.treeCount ||
+				  (verityState.treeCount > 0 && verityState.treeImages.length >= verityState.treeCount) ||
 				  verityState.pageSize * (verityState.currentPage+1) <= verityState.treeImages.length) {
 				// No need to request more images
 				log.debug('cancel load because condition doesn\'t meet')

--- a/client/src/models/verity.js
+++ b/client/src/models/verity.js
@@ -181,6 +181,7 @@ const verity = {
 				...state,
 				treeImages: [],
 				currentPage: 0,
+				treeCount: 0,
 			}
 		},
 		/*
@@ -269,6 +270,7 @@ const verity = {
 			log.debug('to load images')
 			const verityState		= state.verity
 			if (verityState.isLoading ||
+					verityState.treeImages.length >= verityState.treeCount ||
 				  verityState.pageSize * (verityState.currentPage+1) <= verityState.treeImages.length) {
 				// No need to request more images
 				log.debug('cancel load because condition doesn\'t meet')

--- a/client/src/models/verity.js
+++ b/client/src/models/verity.js
@@ -179,7 +179,8 @@ const verity = {
 		reset(state){
 			return {
 				...state,
-				treeImages		: [],
+				treeImages: [],
+				currentPage: 0,
 			}
 		},
 		/*
@@ -188,8 +189,8 @@ const verity = {
 		resetSelection(state){
 			return {
 				...state,
-				treeImagesSelected		: [],
-				treeImageAnchor		: undefined,
+				treeImagesSelected: [],
+				treeImageAnchor: undefined,
 			}
 		},
 		/*

--- a/client/src/models/verity.js
+++ b/client/src/models/verity.js
@@ -38,9 +38,8 @@ const verity = {
 		//cal the complete of progress (0-100)
 		rejectAllComplete		: 0,
 		approveAllComplete		: 0,
-		pagesLoaded		: -1,
-		moreTreeImagesAvailable		: true,
-		pageSize		: 20,
+		pageSize: 12,
+		currentPage: 0,
 		/*
 		 * The default value means: image not approved yet, and not rejected yet too
 		 */
@@ -48,7 +47,7 @@ const verity = {
 			approved		: false,
 			active		: true,
 		}),
-    treeCount: 0,
+		treeCount: 0,
 	},
 	reducers		: {
 		appendTreeImages(state, treeImages){
@@ -56,10 +55,14 @@ const verity = {
       let newState = {
         ...state,
         treeImages: newTreeImages,
-				pagesLoaded		: state.pagesLoaded + 1,
-				isLoading		: false,
       };
-      return newState;
+			return newState;
+		},
+		setTreeImages(state, treeImages){
+			return {
+				...state,
+				treeImages,
+			}
 		},
 		setLoading(state, isLoading){
 			return {
@@ -86,12 +89,6 @@ const verity = {
 				isRejectAllProcessing,
 			}
 		},
-		setPagesLoaded(state, pagesLoaded){
-			return {
-				...state,
-				pagesLoaded,
-			}
-		},
 		setFilter(state, filter){
 			return {
 				...state,
@@ -103,7 +100,7 @@ const verity = {
             ...state,
             treeCount,
         };
-    },
+		},
 		setApproveAllComplete(state, approveAllComplete){
 			return {
 				...state,
@@ -183,8 +180,6 @@ const verity = {
 			return {
 				...state,
 				treeImages		: [],
-				pagesLoaded		: -1,
-				moreTreeImagesAvailable		: true,
 			}
 		},
 		/*
@@ -266,32 +261,33 @@ const verity = {
 			return true
 		},
 		/*
-		 * To load more trees into the list
+		 * To load trees into the list
 		 */
-		async loadMoreTreeImages(payload, state){
+		async loadTreeImages(payload, state){
 			//{{{
 			log.debug('to load images')
 			const verityState		= state.verity
-			if (verityState.isLoading || !verityState.moreTreeImagesAvailable){
+			if (verityState.isLoading ||
+				  verityState.pageSize * (verityState.currentPage+1) <= verityState.treeImages.length) {
+				// No need to request more images
 				log.debug('cancel load because condition doesn\'t meet')
 				return true;
 			}
 			//set loading status
 			this.setLoading(true)
-			const nextPage = verityState.pagesLoaded + 1;
+
 			const pageParams = {
 				//page: nextPage,
 				//REVISE Fri Aug 16 10:56:34 CST 2019
 				//change the api to use skip parameter directly, because there is a
 				//bug to use page as param
 				skip		: verityState.treeImages.length,
-				rowsPerPage: verityState.pageSize,
+				rowsPerPage: verityState.pageSize * (verityState.currentPage+1) - verityState.treeImages.length,
 				filter		: verityState.filter,
 			};
 			log.debug('load page with params:', pageParams)
 			const result		= await api.getTreeImages(pageParams)
 			log.debug('loaded trees:%d', result.length)
-			//verityState.pagesLoaded = nextPage;
 			this.appendTreeImages(result);
 			//restore loading status
 			this.setLoading(false)
@@ -343,7 +339,6 @@ const verity = {
 			this.setApproveAllProcessing(false);
 			this.setRejectAllProcessing(false);
 			//reset
-			this.setPagesLoaded(-1);
 			this.setApproveAllComplete(0);
 			this.resetSelection();
 			return true;
@@ -401,7 +396,6 @@ const verity = {
 			this.setLoading(false);
 			this.setApproveAllProcessing(false);
 			//reset
-			this.setPagesLoaded(-1);
 			this.setApproveAllComplete(0);
 			this.resetSelection();
 			return true;
@@ -441,7 +435,6 @@ const verity = {
 			this.setApproveAllProcessing(false);
 			this.setRejectAllProcessing(false);
 			//reset
-			this.setPagesLoaded(-1);
 			this.setRejectAllComplete(0);
 			this.setApproveAllComplete(0);
 			this.resetSelection();
@@ -457,14 +450,14 @@ const verity = {
 			this.reset()
 			this.resetSelection()
 			//clear all stuff
-			await this.loadMoreTreeImages()
+			await this.loadTreeImages()
 			//}}}
 		},
     /*
      * gets and sets count for unverified trees
      */
-    async getTreeCount() {
-        const result = await api.getUnverifiedTreeCount()
+    async getTreeCount(payload, state) {
+        const result = await api.getTreeCount(state.verity.filter)
         this.setTreeCount(result.count)
         return true
     },

--- a/client/src/models/verity.test.js
+++ b/client/src/models/verity.test.js
@@ -179,6 +179,26 @@ describe('verity', () => {
 				//}}}
 			})
 
+			describe('set pageSize', () => {
+				beforeEach(async () => {
+					await store.dispatch.verity.set({pageSize:24})
+				})
+	
+				it('pageSize should be 24', () => {
+					expect(store.getState().verity.pageSize).toBe(24)
+				})
+			});
+	
+			describe('set currentPage', () => {
+				beforeEach(async () => {
+					store.dispatch.verity.set({currentPage:1})
+				})
+	
+				it('currentPage should be 1', () => {
+					expect(store.getState().verity.currentPage).toBe(1)
+				})
+			});
+	
 			//}}}
 		})
 

--- a/client/src/models/verity.test.js
+++ b/client/src/models/verity.test.js
@@ -23,6 +23,9 @@ describe('verity', () => {
     api.getUnverifiedTreeCount = () => Promise.resolve({
       count   : 1
     });
+    api.getTreeCount = () => Promise.resolve({
+      count   : 1
+    });
 	})
 
 	describe('with a default store', () => {
@@ -39,10 +42,10 @@ describe('verity', () => {
 			expect(store.getState().verity.isLoading).toBe(false)
 		})
 
-		describe('loadMoreTreeImages() ', () => {
+		describe('loadTreeImages() ', () => {
 			//{{{
 			beforeEach(async () => {
-				const result		= await store.dispatch.verity.loadMoreTreeImages()
+				const result		= await store.dispatch.verity.loadTreeImages()
 				expect(result).toBe(true)
 			})
 
@@ -76,13 +79,14 @@ describe('verity', () => {
         })
       })
 
-			describe('approveTreeImage(1, {seedling, new_tree, simple_lead})', () => {
+			describe('approveTreeImage(1, {seedling, new_tree, simple_leaf, 6})', () => {
 				//{{{
         let approveAction = {
           morphology: 'seedling',
           age: 'new_tree',
           isApproved: true,
-          captureApprovalTag: 'simple_lead',
+					captureApprovalTag: 'simple_leaf',
+					speciesId: 6,
         }
 				beforeEach(async () => {
 					const result		= await store.dispatch.verity.approve(
@@ -101,7 +105,7 @@ describe('verity', () => {
         it('api.approve should be called by : id, seedling...', () => {
           console.log(api.approveTreeImage.mock)
 					expect(api.approveTreeImage.mock.calls[0]).toMatchObject(
-            ['1', 'seedling', 'new_tree', 'simple_lead']
+            ['1', 'seedling', 'new_tree', 'simple_leaf', 6]
           )
         })
 
@@ -138,11 +142,11 @@ describe('verity', () => {
 			})
 
 
-			describe('loadMoreTreeImages() load second page', () => {
+			describe('loadTreeImages() load second page', () => {
 				//{{{
 				beforeEach(async () => {
 					api.getTreeImages.mockClear()
-					await store.dispatch.verity.loadMoreTreeImages();
+					await store.dispatch.verity.loadTreeImages();
 				})
 
 				it('should call api with param: skip = 1', () => {
@@ -287,7 +291,8 @@ describe('verity', () => {
             morphology: 'seedling',
             age: 'new_tree',
             isApproved: true,
-            captureApprovalTag: 'simple_leaf',
+						captureApprovalTag: 'simple_leaf',
+						speciesId: 6
           }
 					beforeEach(async () => {
 						await store.dispatch.verity.approveAll({approveAction});
@@ -306,17 +311,13 @@ describe('verity', () => {
 						expect(store.getState().verity.isApproveAllProcessing).toBe(false)
 					})
 
-					it('after approveAll, some page information should be reset, pagesLoaded = -1', () => {
-						expect(store.getState().verity.pagesLoaded).toBe(-1)
-					})
-
 					it('after approveAll, should get an undo list', () => {
 						expect(store.getState().verity.treeImagesUndo).toHaveLength(3)
 					})
 
           it('api.approve should be called with ...', () => {
             expect(api.approveTreeImage.mock.calls[0]).toMatchObject(
-              [7, 'seedling','new_tree','simple_leaf']
+              [7, 'seedling','new_tree','simple_leaf', 6]
             )
           })
 
@@ -365,10 +366,6 @@ describe('verity', () => {
 
 					it('isRejectAllProcessing === false', () => {
 						expect(store.getState().verity.isRejectAllProcessing).toBe(false)
-					})
-
-					it('after rejectAll, some page information should be reset, pagesLoaded = -1', () => {
-						expect(store.getState().verity.pagesLoaded).toBe(-1)
 					})
 
 					it('after rejectAll, should get an undo list', () => {


### PR DESCRIPTION
Resolves #104 

- Pagination component above and below images
- 12, 24, 48 or 96 images per page
- Tree count updated to reflect filter used for tree images
- Only loads more trees if there are more available and not enough to populate the current page

![2020-05-25 (2)](https://user-images.githubusercontent.com/5558838/82789887-fd303500-9e62-11ea-9218-76b1d8f5999a.png)

- Placeholder cards while images are loading

![2020-05-25 (1)](https://user-images.githubusercontent.com/5558838/82789771-cb1ed300-9e62-11ea-863c-57a3a36be109.png)