### PR TITLE
Tweaked text input spacing

### DIFF
--- a/client/src/components/common/theme.js
+++ b/client/src/components/common/theme.js
@@ -53,8 +53,13 @@ export default createMuiTheme({
 		},
 		MuiOutlinedInput		: {
 			input		: {
-				padding		: '10.5px 7px',
-			}
+				padding		: '10.5px 10px',
+			},
+		},
+		MuiInputLabel: {
+			outlined: {
+				transform: 'translate(10px, 12px) scale(1)', 
+			},
 		},
 		MuiListItem		: {
 			root		: {


### PR DESCRIPTION
Resolves #240 

- Moved label back to vertical centre of input (when not focussed)
- Added a touch more padding to the left of the text