### PR TITLE
feat: add user login validation

### DIFF
--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState } from 'react'
 import {
   LinearProgress,
   Checkbox,
@@ -12,13 +12,13 @@ import {
   Typography,
   Container,
   Link,
-} from "@material-ui/core";
-import LockOutlinedIcon from "@material-ui/icons/LockOutlined";
-import IconLogo from "./IconLogo";
-import { withStyles } from "@material-ui/core/styles";
-import {AppContext} from "./MainFrame";
+} from '@material-ui/core'
+import LockOutlinedIcon from '@material-ui/icons/LockOutlined'
+import IconLogo from './IconLogo'
+import { withStyles } from '@material-ui/core/styles'
+import { AppContext } from './MainFrame'
 
-import axios from "axios";
+import axios from 'axios'
 //import { useAuth } from "../context/auth";
 //import Copyright from "components/Copyright";
 //import { useHistory } from "react-router-dom";
@@ -26,77 +26,71 @@ import axios from "axios";
 const styles = (theme) => ({
   paper: {
     marginTop: theme.spacing(8),
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
   },
   avatar: {
     margin: theme.spacing(1),
     backgroundColor: theme.palette.secondary.main,
   },
   form: {
-    width: "100%", // Fix IE 11 issue.
+    width: '100%', // Fix IE 11 issue.
     marginTop: theme.spacing(1),
   },
   submit: {
     margin: theme.spacing(3, 0, 2),
   },
   submitText: {
-    color: "white",
+    color: 'white',
   },
   forgetPassword: {
     margin: theme.spacing(2, 0),
   },
-});
-
+})
 
 const Login = (props) => {
   //const { setAuthToken } = useAuth();
-  const appContext = React.useContext(AppContext);
-  const {
-    touched,
-    errors,
-    isSubmitting,
-    handleChange: onChange,
-    handleBlur: onBlur,
-  } = {};
-  const { classes } = props;
-  const [userName, setUsername] = React.useState("");
-  const [password, setPassword] = React.useState("");
-  const [errorMessage, setErrorMessage] = React.useState("");
-  
+  const appContext = React.useContext(AppContext)
+  const { touched, errors, isSubmitting, handleChange: onChange, handleBlur: onBlur } = {}
+  const { classes } = props
+  const [userName, setUsername] = React.useState('')
+  const [password, setPassword] = React.useState('')
+  const [errorMessage, setErrorMessage] = React.useState('')
 
-  function handleUsernameChange(e){
-    setUsername(e.target.value);
+  function handleUsernameChange(e) {
+    setUsername(e.target.value)
   }
 
-  function handlePasswordChange(e){
-    setPassword(e.target.value);
+  function handlePasswordChange(e) {
+    setPassword(e.target.value)
   }
 
-  function handleSubmit(e){
-    e.preventDefault();
-    e.stopPropagation();
-    (async () => {
+  function handleSubmit(e) {
+    e.preventDefault()
+    e.stopPropagation()
+    ;(async () => {
       //TODO login request
-      try{
-        const res = await axios.post(`${process.env.REACT_APP_API_ROOT}/auth/login`,{
+      try {
+        const res = await axios.post(`${process.env.REACT_APP_API_ROOT}/auth/login`, {
           userName,
           password,
-        });
-        if(res.status === 200){
-          const token = res.data.token;
-          const user = res.data.user;
-          appContext.login(user, token);
-        }else{
-          setErrorMessage("Invalid user name or password!");
+        })
+        if (res.status === 200) {
+          const token = res.data.token
+          const user = res.data.user
+          appContext.login(user, token)
+        } else {
+          setErrorMessage('Invalid user name or password!')
         }
-      }catch(e){
-        console.error(e);
-        setErrorMessage("Can not login, please check your username passowrd or contact the admin ...");
+      } catch (e) {
+        console.error(e)
+        setErrorMessage(
+          'Can not login, please check your username passowrd or contact the admin ...'
+        )
       }
-    })();
-    return false;
+    })()
+    return false
   }
 
   if (isSubmitting) {
@@ -105,8 +99,7 @@ const Login = (props) => {
         <LinearProgress />
         Vent venligst...
       </Typography>
-    );
-
+    )
   }
 
   return (
@@ -118,9 +111,9 @@ const Login = (props) => {
           <LockOutlinedIcon />
         </Avatar>
         */}
-        <IconLogo/>
+        <IconLogo />
         <Box m={2} />
-        <Typography variant="h2" >Admin Panel</Typography>
+        <Typography variant="h2">Admin Panel</Typography>
         {/*
         <Typography component="h1" variant="h5">
           Sign in
@@ -136,8 +129,10 @@ const Login = (props) => {
             label="userName"
             name="userName"
             autoComplete="userName"
-            helperText={""/*touched.email ? errors.email : ""*/}
-            error={""/*touched.email && Boolean(errors.email)*/}
+            helperText={
+              userName === '' ? 'Field is required' : '' /*touched.email ? errors.email : ""*/
+            }
+            error={userName === '' /*touched.email && Boolean(errors.email)*/}
             onChange={handleUsernameChange}
             value={userName}
           />
@@ -151,8 +146,10 @@ const Login = (props) => {
             type="password"
             id="password"
             autoComplete="current-password"
-            helperText={""/*touched.password ? errors.password : ""*/}
-            error={""/*touched.password && Boolean(errors.password)*/}
+            helperText={
+              password === '' ? 'Field is required' : '' /*touched.password ? errors.password : ""*/
+            }
+            error={password === '' /*touched.password && Boolean(errors.password)*/}
             onChange={handlePasswordChange}
             value={password}
           />
@@ -183,7 +180,7 @@ const Login = (props) => {
             color="primary"
             className={classes.submit}
           >
-            <Typography className={classes.submitText} >LOGIN</Typography>
+            <Typography className={classes.submitText}>LOGIN</Typography>
           </Button>
           {/*
           <Grid container justify="center">
@@ -197,7 +194,7 @@ const Login = (props) => {
         </form>
       </div>
     </Container>
-  );
-};
+  )
+}
 
-export default withStyles(styles)(Login);
+export default withStyles(styles)(Login)


### PR DESCRIPTION
required validation is added to the user login

Tbh this is kinda ugly... from UX perspective we are giving a big  RED before user starts to do anything. 
Later refactoring can be:
- replace "cannot be empty error" with a tooltip(https://material-ui.com/components/tooltips/)
- customise error box to make it yellow when render  "cannot be empty"  and have red color for other errors later

![Jun-04-2020 22-42-09](https://user-images.githubusercontent.com/29664811/83813293-f9977c00-a6b4-11ea-9630-1a91d287fbea.gif)
