### PR TITLE
Bypass JWT authentication for API explorer, update README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ docker logs -f treetracker-admin-api
 
 Also see _Scripts_ below
 
-The REST API documentation can be viewed and explored by visiting http://localhost:3000/explorer
+The REST API documentation can be viewed and explored by visiting http://localhost:3000/api/explorer
 
 To stop the dev environment use
 

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -361,7 +361,7 @@ const isAuth = (req, res, next) => {
   //white list
   //console.error("req.originalUrl", req.originalUrl);
   const url = req.originalUrl;
-  if (url === '/auth/login' || url === '/auth/test' || url === '/auth/init') {
+  if (url === '/auth/login' || url === '/auth/test' || url === '/auth/init' || url.startsWith('/api/explorer/')) {
     next();
     return;
   }


### PR DESCRIPTION
Fix issue #244 

Authentication was blocking the explorer HTTP requests.

Should we validate the development environment before bypassing the authentication?