### PR TITLE
Do not reload all trees after each verification

### DIFF
--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -291,19 +291,23 @@ const TreeImageScrubber = (props) => {
     return props.verityState.treeImagesSelected.indexOf(id) >= 0
   }
 
-  const placeholderImages = Array(props.verityState.pageSize).fill().map((_, index) => {
-    return {
-      id: index,
-      placeholder: true,
-    };
-  });
-
   const treeImages = props.verityState.treeImages.filter((tree, index) => {
     return index >= props.verityState.currentPage * props.verityState.pageSize &&
            index < (props.verityState.currentPage+1) * props.verityState.pageSize;
   });
 
-  const treeImageItems = (props.verityState.isLoading ? placeholderImages : treeImages)
+  const placeholderImages =
+    props.verityState.isLoading ?
+      Array(props.verityState.pageSize - treeImages.length)
+      .fill().map((_, index) => {
+        return {
+          id: index,
+          placeholder: true,
+        };
+      })
+    : [];
+
+  const treeImageItems = treeImages.concat(placeholderImages)
     .map(tree => {
       return (
         <Grid item xs={12} sm={6} md={4} xl={3}>
@@ -357,8 +361,7 @@ const TreeImageScrubber = (props) => {
           </div>
         </Grid>
       );
-    }
-  );
+    });
 
   function handleFilterClick() {
     if (isFilterShown) {


### PR DESCRIPTION
Resolves #286 

Instead of showing a full page of placeholder cards whenever additional trees are being loaded we now only use placeholders for trees that have not yet loaded.
When verifying trees, this typically means one or more trees at the end of the page, minimising disruption to the user.

![Greenstand - Tree Tracker - Google Chrome 2020-06-26 12-52-22](https://user-images.githubusercontent.com/5558838/85855054-806be000-b7ad-11ea-938e-222be0543e41.gif)
