### PR TITLE
Moved planter detail to new component and added to verify page

### DIFF
--- a/client/src/api/planters.js
+++ b/client/src/api/planters.js
@@ -2,6 +2,19 @@ import { handleResponse, handleError } from "./apiUtils";
 import {session} from "../models/auth";
 
 export default {
+  getPlanter(id){
+    const query = `${process.env.REACT_APP_API_ROOT}/api/planter/${id}`;
+    return fetch(query, {
+      method: "GET",
+      headers: { 
+        "content-type": "application/json" ,
+        Authorization: session.token ,
+      },
+    })
+      .then(handleResponse)
+      .catch(handleError);
+  },
+
   getPlanters({ skip, rowsPerPage, orderBy = "id", order = "desc", filter }) {
     const query =
       `${process.env.REACT_APP_API_ROOT}/api/planter?` +

--- a/client/src/components/PlanterDetail.js
+++ b/client/src/components/PlanterDetail.js
@@ -1,0 +1,115 @@
+import React from 'react'
+import { makeStyles, withStyles } from '@material-ui/core/styles'
+import Typography from '@material-ui/core/Typography'
+import CardMedia from '@material-ui/core/CardMedia'
+import Grid from '@material-ui/core/Grid'
+import IconButton from '@material-ui/core/IconButton'
+import Box from '@material-ui/core/Box'
+import Drawer from '@material-ui/core/Drawer'
+import Close from "@material-ui/icons/Close";
+import Person from "@material-ui/icons/Person";
+import Divider from "@material-ui/core/Divider";
+
+const useStyle = makeStyles(theme => ({
+    root: {
+      width: 441,
+    },
+    box: {
+      padding: theme.spacing(4),
+    },
+    cardMedia: {
+      height: "378px",
+    },
+    personBox: {
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      backgroundColor: "lightgray",
+      height: "100%",
+    },
+    person: {
+      height: 180,
+      width: 180,
+      fill: "gray",
+    },
+    name: {
+      textTransform: "capitalize",
+    },
+  }));
+
+function PlanterDetail(props){
+
+    const classes = useStyle();
+    const {
+      planter,
+    } = props;
+  
+    return(
+      <Drawer anchor="right" open={props.open} onClose={props.onClose}>
+        <Grid className={classes.root} >
+          <Grid container direction="column">
+            <Grid item>
+              <Grid container justify="space-between" alignItems="center" >
+                <Grid item>
+                  <Box m={4} >
+                    <Typography color="primary" variant="h6" >
+                      Planter Detail
+                    </Typography>
+                  </Box>
+                </Grid>
+                <Grid item>
+                  <IconButton>
+                    <Close onClick={() => props.onClose()} />
+                  </IconButton>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+  
+              {planter.imageUrl &&
+                <CardMedia className={classes.cardMedia} image={planter.imageUrl} />
+              }
+              {!planter.imageUrl &&
+                <CardMedia className={classes.cardMedia} >
+                  <Grid container className={classes.personBox} >
+                    <Person className={classes.person} />
+                  </Grid>
+                </CardMedia>
+              }
+            </Grid>
+            <Grid item className={classes.box} >
+              <Typography variant="h5" color="primary" className={classes.name} >{props.planter.firstName} {props.planter.lastName}</Typography>
+              <Typography variant="body2">ID:{props.planter.id}</Typography>
+            </Grid>
+            <Divider/>
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1" >Email address</Typography>
+              <Typography variant="body1" >{props.planter.email || "---"}</Typography>
+            </Grid>
+            <Divider/>
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1" >Phone number</Typography>
+              <Typography variant="body1" >{props.planter.phone || "---"}</Typography>
+            </Grid>
+            <Divider/>
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1" >Person ID</Typography>
+              <Typography variant="body1" >{props.planter.personId || "---"}</Typography>
+            </Grid>
+            <Divider/>
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1" >Organization</Typography>
+              <Typography variant="body1" >{props.planter.organization || "---" }</Typography>
+            </Grid>
+            <Divider />
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1" >Organization ID</Typography>
+              <Typography variant="body1" >{props.planter.organizationId || "---"}</Typography>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Drawer>
+    )
+  }
+
+  export default (PlanterDetail)

--- a/client/src/components/Planters.js
+++ b/client/src/components/Planters.js
@@ -51,6 +51,7 @@ import Avatar from "@material-ui/core/Avatar";
 import Person from "@material-ui/icons/Person";
 import Divider from "@material-ui/core/Divider";
 import Navbar from "./Navbar";
+import PlanterDetail from "./PlanterDetail"
 
 const log = require('loglevel').getLogger('../components/Planters')
 
@@ -299,7 +300,7 @@ const Planters = (props) => {
           </Grid>
         </Grid>
       </Grid>
-      <Detail open={isDetailShown} planter={planterDetail} onClose={() => setDetailShown(false)} />
+      <PlanterDetail open={isDetailShown} planter={planterDetail} onClose={() => setDetailShown(false)} />
     </React.Fragment>
   )
 }
@@ -343,109 +344,6 @@ function Planter (props){
   )
 }
 export {Planter};
-
-
-const useDetailStyle = makeStyles(theme => ({
-  root: {
-    width: 441,
-  },
-  box: {
-    padding: theme.spacing(4),
-  },
-  cardMedia: {
-    height: "378px",
-  },
-  personBox: {
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    backgroundColor: "lightgray",
-    height: "100%",
-  },
-  person: {
-    height: 180,
-    width: 180,
-    fill: "gray",
-  },
-  name: {
-    textTransform: "capitalize",
-  },
-}));
-
-function Detail(props){
-  const classes = useDetailStyle();
-  const {
-    planter,
-  } = props;
-
-  return(
-    <Drawer anchor="right" open={props.open} onClose={props.onClose}>
-      <Grid className={classes.root} >
-        <Grid container direction="column">
-          <Grid item>
-            <Grid container justify="space-between" alignItems="center" >
-              <Grid item>
-                <Box m={4} >
-                  <Typography color="primary" variant="h6" >
-                    Planter Detail
-                  </Typography>
-                </Box>
-              </Grid>
-              <Grid item>
-                <IconButton>
-                  <Close onClick={() => props.onClose()} />
-                </IconButton>
-              </Grid>
-            </Grid>
-          </Grid>
-          <Grid item>
-
-            {planter.imageUrl &&
-              <CardMedia className={classes.cardMedia} image={planter.imageUrl} />
-            }
-            {!planter.imageUrl &&
-              <CardMedia className={classes.cardMedia} >
-                <Grid container className={classes.personBox} >
-                  <Person className={classes.person} />
-                </Grid>
-              </CardMedia>
-            }
-          </Grid>
-          <Grid item className={classes.box} >
-            <Typography variant="h5" color="primary" className={classes.name} >{props.planter.firstName} {props.planter.lastName}</Typography>
-            <Typography variant="body2">ID:{props.planter.id}</Typography>
-          </Grid>
-          <Divider/>
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Email address</Typography>
-            <Typography variant="body1" >{props.planter.email || "---"}</Typography>
-          </Grid>
-          <Divider/>
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Phone number</Typography>
-            <Typography variant="body1" >{props.planter.phone || "---"}</Typography>
-          </Grid>
-          <Divider/>
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Person ID</Typography>
-            <Typography variant="body1" >{props.planter.personId || "---"}</Typography>
-          </Grid>
-          <Divider/>
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Organization</Typography>
-            <Typography variant="body1" >{props.planter.organization || "---" }</Typography>
-          </Grid>
-          <Divider />
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Organization ID</Typography>
-            <Typography variant="body1" >{props.planter.organizationId || "---"}</Typography>
-          </Grid>
-        </Grid>
-      </Grid>
-    </Drawer>
-  )
-}
-export {Detail}
 
 export default connect(
   //state

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -43,9 +43,11 @@ import Filter, { FILTER_WIDTH } from './Filter';
 import FilterTop from './FilterTop';
 import { ReactComponent as TreePin } from '../components/images/highlightedPinNoStick.svg';
 import CheckIcon from '@material-ui/icons/Check';
+import Person from "@material-ui/icons/Person";
 import Paper from '@material-ui/core/Paper';
 import TablePagination from '@material-ui/core/TablePagination';
 import Navbar from "./Navbar";
+import PlanterDetail from "./PlanterDetail"
 
 const log = require('loglevel').getLogger('../components/TreeImageScrubber');
 
@@ -180,6 +182,7 @@ const TreeImageScrubber = (props) => {
   const [complete, setComplete] = React.useState(0);
   const [isFilterShown, setFilterShown] = React.useState(false);
   const [dialog, setDialog] = React.useState({isOpen: false, tree: {}});
+  const [planterDetail, setPlanterDetail] = React.useState({isOpen: false, planter: {}})
   const refContainer = React.useRef();
 
   /*
@@ -263,6 +266,29 @@ const TreeImageScrubber = (props) => {
     props.verityDispatch.loadTreeImages();
   }
 
+  async function handlePlanterDetail(e, tree){
+    e.preventDefault();
+    e.stopPropagation();
+    var planter = props.plantersState.planters.find(x => x.id == tree.planterId);
+    if (!planter) {
+      planter = await props.plantersDispatch.getPlanter({id: tree.planterId});
+    }
+    if(!planter){
+      window.alert(`Planter not found id:${tree.planterId}`)
+    }
+    setPlanterDetail({
+      isOpen: true, 
+      planter: planter,
+    });
+  }
+
+  function handlePlanterDetailClose(){
+    setPlanterDetail({
+      isOpen: false,
+      planter: {},
+    })
+  }
+
   function handleDialog(e, tree){
     e.preventDefault();
     e.stopPropagation();
@@ -342,6 +368,10 @@ const TreeImageScrubber = (props) => {
                   justify='flex-end'
                   container>
                   <Grid item>
+                    <Person
+                      color='primary'
+                      onClick={e => handlePlanterDetail(e, tree)}
+                    />
                     <Image
                       color='primary'
                       onClick={e => handleDialog(e, tree)}
@@ -508,6 +538,11 @@ const TreeImageScrubber = (props) => {
             className={classes.snackbar}
           />
         )}
+      <PlanterDetail 
+        open={planterDetail.isOpen} 
+        planter={planterDetail.planter} 
+        onClose={() => handlePlanterDetailClose()} 
+      />
       <Dialog
         open={dialog.isOpen}
         TransitionComponent={Transition}
@@ -714,10 +749,12 @@ export default connect(
   state => ({
     verityState: state.verity,
     speciesState: state.species,
+    plantersState: state.planters,
   }),
   //dispatch
   dispatch => ({
     verityDispatch: dispatch.verity,
     speciesDispatch: dispatch.species,
+    plantersDispatch: dispatch.planters,
   })
 )(TreeImageScrubber);

--- a/client/src/models/planters.js
+++ b/client/src/models/planters.js
@@ -60,6 +60,14 @@ const planters = {
      *  pageNumber,
      * }
      */
+    async getPlanter(payload, state){
+      this.setIsLoading(true);
+      const planter = await api.getPlanter(payload.id);
+      this.setPlanters([planter, ...state.planters.planters]);
+      this.setIsLoading(false);
+      return planter;
+    },
+
     async load(payload, state){
       this.setIsLoading(true);
       const planters = await api.getPlanters({

--- a/server/src/models/planter.model.ts
+++ b/server/src/models/planter.model.ts
@@ -55,12 +55,12 @@ export class Planter extends Entity {
   })
   pwdResetRequired?: Boolean;
 
-  @property({
-    type: String,
-    required: false,
-    postgresql: {"columnName":"salt","dataType":"character varying","dataLength":null,"dataPrecision":null,"dataScale":null,"nullable":"YES"},
-  })
-  salt?: String;
+  // @property({
+  //   type: String,
+  //   required: false,
+  //   postgresql: {"columnName":"salt","dataType":"character varying","dataLength":null,"dataPrecision":null,"dataScale":null,"nullable":"YES"},
+  // })
+  // salt?: String;
 
   @property({
     type: String,


### PR DESCRIPTION
#315 After looking into react-router I decided this wasn't ideal since there is no "planter detail page" to navigate to from the verify page. Also, I think a user would not want to be routed away from the verify page when looking at a planter if possible. Instead I moved the detail to its own component and created the necessary states and redux mapping to get the planter detail component viewable from the verify page.

@dadiorchen let me know if this approach is okay.

![image](https://user-images.githubusercontent.com/63984391/88464306-d6987580-ce76-11ea-9db0-a0e25a03fd4f.png)
