### PR TITLE
#316 format date time according to users location

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,2 +1,2 @@
 REACT_APP_WEBMAP_DOMAIN=http://dev.treetracker.org
-REACT_APP_API_ROOT=http://localhost:3000
+/*REACT_APP_API_ROOT=http://localhost:3000*/

--- a/client/.env.development
+++ b/client/.env.development
@@ -1,2 +1,2 @@
 REACT_APP_WEBMAP_DOMAIN=http://dev.treetracker.org
-/*REACT_APP_API_ROOT=http://localhost:3000*/
+REACT_APP_API_ROOT=http://localhost:3000

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,12 +3,14 @@ import { connect } from 'react-redux'
 import { ThemeProvider } from '@material-ui/core/styles'
 import MainFrame from './components/MainFrame'
 import theme from './components/common/theme'
+import {setLocaleLanguage} from './common/locale'
 
 class App extends Component {
   componentDidMount() {
     // in the future we want to maybe restore the users last filter set from the server
     // as well as deal with all the login state stuff.
     this.props.requestTreeCount()
+    setLocaleLanguage(navigator.language);
   }
 
   render() {

--- a/client/src/common/locale.js
+++ b/client/src/common/locale.js
@@ -1,0 +1,102 @@
+import enLocale from 'date-fns/locale/en-US';
+import DateFnsUtils from '@date-io/date-fns';
+import dateformat from 'dateformat'
+
+// Per default set to EN
+var localeLanguage = 'en';
+// default date pattern when converting dates
+// to work with sql queries
+const defaultSqlDatePattern = 'yyyy-mm-dd';
+
+// Contains the locale for the DatePicker
+// now only EN is used, otherwise, many imports 
+// bloat up the application size
+// Later this should be rendered server side
+const localeMap = {
+  en: enLocale
+};
+
+// General display options for the date
+const dateOptions = { 
+  year: 'numeric', 
+  month: 'numeric', 
+  day: '2-digit'
+};
+
+// General display options for the time
+const timeOptions = {
+  hour: 'numeric', 
+  minute: 'numeric' 
+};
+
+// Returns a date or dateTime format string depending on the locale
+// and options set in dateOptions and timeOptions
+const getDateTimeFormatString = (includeTime , forMuiDatepicker) => {
+  const intlOptions = includeTime ? {...dateOptions, ...timeOptions} : dateOptions;
+  const intlDateTimeFormat = new Intl.DateTimeFormat(localeLanguage, intlOptions);
+  const formatDateTimeObj = intlDateTimeFormat.formatToParts(new Date());
+  const is12HourTimeZone = intlDateTimeFormat.resolvedOptions().hour12;
+
+  return formatDateTimeObj
+    .map(obj => {
+      switch (obj.type) {
+        case 'day':
+          return 'dd';
+        case 'month':
+          return forMuiDatepicker ? 'MM' : 'mm';
+        case 'year':
+          return 'yyyy';
+        case 'hour':
+          // Check if locale is a 12-hour or 24-hour timezone
+          return is12HourTimeZone ? 'hh' : 'HH';
+        case 'minute':
+          return forMuiDatepicker ? 'mm' : 'MM';
+        case 'dayPeriod':
+          return is12HourTimeZone ? (forMuiDatepicker ? 'a' : 'tt') : '';
+        default:
+          return obj.value;
+      }
+    })
+    .join("");
+}
+
+// set the locale language
+const setLocaleLanguage = (language) => {
+  localeLanguage = language;
+}
+
+// DatePicker Locale - default is 'en'
+const getDatePickerLocale = () => {
+  return localeMap['en'];
+}
+
+const getDateFormatLocale = (forMuiDatepicker = false) => {
+  return getDateTimeFormatString(false, forMuiDatepicker);
+}
+
+const getDateTimeFormatLocale = (forMuiDatepicker = false) => {
+  return getDateTimeFormatString(true, forMuiDatepicker);
+}
+
+const getDateStringLocale = (date, forMuiDatepicker = false) => {
+  return dateformat(date, getDateFormatLocale(forMuiDatepicker));
+}
+
+const getDateTimeStringLocale = (date, forMuiDatepicker = false) => {
+  return dateformat(date, getDateTimeFormatLocale(forMuiDatepicker));
+}
+
+// used for converting application date to sql readable date format
+const convertDateToDefaultSqlDate = (date) => {
+  return dateformat(date, defaultSqlDatePattern);
+}
+
+export {
+  setLocaleLanguage,
+  getDatePickerLocale,
+  getDateFormatLocale,
+  getDateTimeFormatLocale,
+  getDateStringLocale,
+  getDateTimeStringLocale,
+  convertDateToDefaultSqlDate
+}

--- a/client/src/components/Account.js
+++ b/client/src/components/Account.js
@@ -18,7 +18,7 @@ import Menu from './common/Menu'
 import AccountIcon from '@material-ui/icons/Person'
 import { AppContext } from './MainFrame'
 import axios from 'axios'
-import dateformat from 'dateformat'
+import { getDateTimeStringLocale } from '../common/locale'
 
 const style = (theme) => ({
   box: {
@@ -257,7 +257,7 @@ function Account(props) {
                 <Grid item>
                   <Typography className={classes.title}>Created</Typography>
                   <Typography className={classes.item}>
-                    {dateformat(user.createdAt, 'm/d/yyyy h:MMtt')}
+                    {getDateTimeStringLocale(user.createdAt)}
                   </Typography>
                 </Grid>
                 <Grid item xs="8">

--- a/client/src/components/Filter.js
+++ b/client/src/components/Filter.js
@@ -9,11 +9,11 @@ import Typography from '@material-ui/core/Typography'
 import TextField from '@material-ui/core/TextField'
 import MenuItem from '@material-ui/core/MenuItem'
 import FilterModel from '../models/Filter'
-import dateformat from 'dateformat'
 import GSInputLabel from './common/InputLabel'
 import classNames from 'classnames'
 import DateFnsUtils from '@date-io/date-fns'
 import { MuiPickersUtilsProvider, KeyboardDatePicker } from '@material-ui/pickers'
+import { getDatePickerLocale, getDateFormatLocale, convertDateToDefaultSqlDate } from '../common/locale'
 
 export const FILTER_WIDTH = 330
 
@@ -66,7 +66,7 @@ function Filter(props) {
   }
 
   const formatDate = (date) => {
-    return dateformat(date, 'yyyy-mm-dd')
+    return convertDateToDefaultSqlDate(date)
   }
 
   function handleClear() {
@@ -232,15 +232,16 @@ function Filter(props) {
         ))}
       </TextField>
       <GSInputLabel text="Time created" />
-      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <MuiPickersUtilsProvider utils={DateFnsUtils} locale={getDatePickerLocale()}>
         <Grid container justify="space-between">
           <KeyboardDatePicker
             margin="normal"
             id="start-date-picker"
             label="Start Date"
-            format="MM/dd/yyyy"
             value={dateStart}
             onChange={handleDateStartChange}
+            format={getDateFormatLocale(true)}
+            maxDate={dateEnd}
             KeyboardButtonProps={{
               'aria-label': 'change date',
             }}
@@ -250,9 +251,10 @@ function Filter(props) {
             margin="normal"
             id="end-date-picker"
             label="End Date"
-            format="MM/dd/yyyy"
             value={dateEnd}
             onChange={handleDateEndChange}
+            format={getDateFormatLocale(true)}
+            minDate={dateStart}
             KeyboardButtonProps={{
               'aria-label': 'change date',
             }}

--- a/client/src/components/FilterTop.js
+++ b/client/src/components/FilterTop.js
@@ -10,7 +10,6 @@ import TextField from '@material-ui/core/TextField';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import FilterModel from '../models/Filter';
-import dateformat from 'dateformat';
 import GSInputLabel from './common/InputLabel';
 import classNames from 'classnames';
 import DateFnsUtils from '@date-io/date-fns';
@@ -21,6 +20,7 @@ import {
   MuiPickersUtilsProvider,
   KeyboardDatePicker
 } from '@material-ui/pickers';
+import { getDatePickerLocale, getDateFormatLocale, convertDateToDefaultSqlDate } from '../common/locale'
 
 export const FILTER_WIDTH = 330;
 
@@ -99,7 +99,7 @@ function Filter(props) {
   };
 
   const formatDate = date => {
-    return dateformat(date, 'yyyy-mm-dd');
+    return convertDateToDefaultSqlDate(date);
   };
 
   function handleClear() {
@@ -189,14 +189,15 @@ function Filter(props) {
                 </MenuItem>
               ))}
             </TextField>
-            <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <MuiPickersUtilsProvider utils={DateFnsUtils} locale={getDatePickerLocale()}>
               <KeyboardDatePicker
                 margin='normal'
                 id='start-date-picker'
                 label='Start Date'
-                format='MM/dd/yyyy'
+                format={getDateFormatLocale(true)}
                 value={dateStart}
                 onChange={handleDateStartChange}
+                maxDate={dateEnd}
                 KeyboardButtonProps={{
                   'aria-label': 'change date'
                 }}
@@ -207,9 +208,10 @@ function Filter(props) {
                 margin='normal'
                 id='end-date-picker'
                 label='End Date'
-                format='MM/dd/yyyy'
+                format={getDateFormatLocale(true)}
                 value={dateEnd}
                 onChange={handleDateEndChange}
+                minDate={dateStart}
                 KeyboardButtonProps={{
                   'aria-label': 'change date'
                 }}

--- a/client/src/components/FilterTopPlanter.js
+++ b/client/src/components/FilterTopPlanter.js
@@ -10,7 +10,6 @@ import TextField from '@material-ui/core/TextField';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import FilterModel from '../models/FilterPlanter';
-import dateformat from 'dateformat';
 import GSInputLabel from './common/InputLabel';
 import classNames from 'classnames';
 import DateFnsUtils from '@date-io/date-fns';

--- a/client/src/components/TreeTable.js
+++ b/client/src/components/TreeTable.js
@@ -3,10 +3,10 @@ import compose from 'recompose/compose'
 import { connect } from 'react-redux'
 import { withStyles } from '@material-ui/core/styles'
 import MUIDataTable from 'mui-datatables'
-import dateformat from 'dateformat'
 import Filter, { FILTER_WIDTH } from './Filter'
 import FilterModel from '../models/Filter'
 import { MENU_WIDTH } from './common/Menu'
+import { getDateTimeStringLocale } from '../common/locale'
 
 import Drawer from '@material-ui/core/Drawer'
 
@@ -150,7 +150,7 @@ class TreeTable extends Component {
         name: 'timeCreated',
         label: 'Created',
         options: {
-          customBodyRender: (v) => `${dateformat(v, 'm/d/yyyy h:Mtt')}`,
+          customBodyRender: (v) => `${getDateTimeStringLocale(v)}`,
         },
       },
     ]

--- a/client/src/components/Users.js
+++ b/client/src/components/Users.js
@@ -41,6 +41,7 @@ import axios from 'axios'
 import { AppContext } from './MainFrame'
 import pwdGenerator from 'generate-password'
 import dateformat from 'dateformat'
+import { getDateTimeStringLocale } from '../common/locale'
 
 const style = (theme) => ({
   box: {
@@ -450,7 +451,7 @@ function Users(props) {
           ))}
         </TableCell>
         <TableCell component="th" scope="row">
-          {dateformat(user.createdAt, 'm/d/yyyy h:MMtt')}
+          {getDateTimeStringLocale(user.createdAt)}
         </TableCell>
         <TableCell>
           <IconButton title="edit" onClick={() => handleEdit(user)}>
@@ -613,7 +614,7 @@ function Users(props) {
               </Grid>
               <Grid item>
                 <Typography variant="outline">
-                  {userEditing && dateformat(userEditing.createdAt, 'm/d/yyyy h:MMtt')}
+                  {userEditing && getDateTimeStringLocale(userEditing.createdAt)}
                 </Typography>
               </Grid>
             </Grid>


### PR DESCRIPTION
Resolves #316 

- Added locale class to take care of all date/time formatting issues in one place
- Datepicker uses english language in the overlay panel as adding many language would add too much overhead currently
- all Dates in the application are formatted according to the users location (currently this was tested by myself with germand and english language, please give feedback if there are issues for other languages or some formats are not correct)
- changed all calls for date/time formatting in the application to the new locale class