### PR TITLE
Protect the DB from deletion when test

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
     "startTest": "NODE_DB=test npm run build && NODE_DB=test DEBUG=loopback:* node ./dist/indexTest.js",
     "prepublishOnly": "npm run test",
     "test": "NODE_DB=test jest --watchAll --runInBand",
-    "test:debug": "DEBUG=loopback:*,express:* jest --no-cache --watchAll --runInBand",
+    "test:debug": "NODE_DB=test DEBUG=loopback:*,express:* jest --no-cache --watchAll --runInBand",
     "watch": "onchange 'src/controllers/**/*.ts' 'src/models/**/*.ts' 'src/repositories/**/*.ts' -- npm run build"
   },
   "repository": {

--- a/server/src/__tests__/seed/seed.ts
+++ b/server/src/__tests__/seed/seed.ts
@@ -1,7 +1,7 @@
 import seed from '../../tests/seed/seed';
-import db from '../../datasources/treetracker.datasource.json';
+import getDatasource from '../../../src/datasources/config';
 import {Pool} from 'pg';
-const pool = new Pool({connectionString: db.url});
+const pool = new Pool({connectionString: getDatasource().url});
 
 describe('Seed data into DB', () => {
   beforeAll(async () => {

--- a/server/src/datasources/config.ts
+++ b/server/src/datasources/config.ts
@@ -9,6 +9,11 @@ export interface DatasourceConfig {
   database: string;
 }
 
+//check the test env, if this is testing, then the NODE_DB=test must be set
+if(process.env.NODE_ENV === 'test' && process.env.NODE_DB !== 'test' ){
+  throw new Error("This is test env, please set NODE_DB === 'test'");
+}
+
 const config: DatasourceConfig =
   process.env.NODE_DB === 'test'
     ? require('./treetrackerTest.datasource.json')

--- a/server/src/datasources/config.ts
+++ b/server/src/datasources/config.ts
@@ -1,3 +1,7 @@
+//NOTE, here import datasource json is just for Typescript compile purpose, 
+//we must import it to let TS cp this json file to the dist folder
+import _ from "./treetracker.datasource.json"
+
 export interface DatasourceConfig {
   name: string;
   connector: string;

--- a/server/src/js/Audit.js
+++ b/server/src/js/Audit.js
@@ -5,8 +5,8 @@
  */
 import {Pool} from 'pg';
 // import log from 'loglevel';
-import db from '../datasources/treetracker.datasource.json';
 // import {strict as assert} from 'assert';
+import getDatasource from '../datasources/config';
 
 const operations = {
   login: {
@@ -69,7 +69,7 @@ export const auditMiddleware = (request, response, next) => {
 
 class Audit {
   constructor() {
-    this.pool = new Pool({connectionString: db.url});
+    this.pool = new Pool({connectionString: getDatasource().url});
   }
 
   async did(req, res) {

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -11,16 +11,12 @@ import config from '../config';
 import {Pool} from 'pg';
 import {utils} from './utils';
 import {helper} from './helper';
-const db =
-  process.env.NODE_DB === 'test'
-    ? require('../datasources/treetrackerTest.datasource.json')
-    : require('../datasources/treetracker.datasource.json');
+import getDatasource  from '../datasources/config';
 import policy from '../policy.json';
 import expect from 'expect';
-// import Audit from './Audit';
 
 const app = express();
-const pool = new Pool({connectionString: db.url});
+const pool = new Pool({connectionString: getDatasource().url});
 const jwtSecret = config.jwtSecret;
 
 const POLICIES = {
@@ -115,8 +111,6 @@ router.post('/login', async function login(req, res, next) {
         role,
         policy,
       } = userLogin;
-      //      const audit = new Audit();
-      //      await audit.did(userLogin.id, Audit.TYPE.LOGIN, req);
       console.log('login success');
       res.json({
         token,

--- a/server/src/js/auth.test.js
+++ b/server/src/js/auth.test.js
@@ -13,12 +13,12 @@ Pool.mockImplementation(() => ({
 }));
 const {auth} = require('./auth.js');
 
-jest.mock('./Audit');
-const Audit = require('./Audit');
-const audit = {
-  did: jest.fn(),
-};
-Audit.mockImplementation(() => audit);
+//jest.mock('./Audit');
+//const Audit = require('./Audit');
+//const audit = {
+//  did: jest.fn(),
+//};
+//Audit.mockImplementation(() => audit);
 
 describe.skip('auth', () => {
   let app;


### PR DESCRIPTION
Features:
* Make sure all the DB connection are get connected by the datasource/config.ts
* Add a check for the NODE_DB=test configruestion: if it's test, like Jest, it would set the NODE_ENV = test by default, so if it was set, then must make sure the NODE_DB=test, otherwise, throw error to block the connection.