### PR TITLE
Replace treetracker.datasource.json with DATABASE_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Treetracker Admin Panel
 
-This portion of the project is to process tree data. TreeTracker's Admin Panel Frontend and RESTful API built with loopback.
+This portion of the project is to process tree data. Treetracker's Admin Panel Frontend and RESTful API built with loopback.
 
 See [Wiki](https://github.com/Greenstand/treetracker-admin-api/wiki) for more info on goals
 
@@ -45,15 +45,15 @@ git clone https://github.com/Greenstand/treetracker-admin.git
 Once cloned, type:
 
 ```
-cd treetracker-admin/server && touch .env src/datasources/treetracker.datasource.json
+cd treetracker-admin/server && touch .env .env.development
 ```
 
 This sets up the following:
 
-- A `treetracker.datasource.json` file in `server/src/datasources/` that will be used to reference the source of data for Loopback.
 - A `.env` file in `server` that will contain a JWT secrect.
+- A `.env.development` file in `server` that will contain a development database connection string.
 
-_**Contact the #admin-panel channel** on Slack (you'll need to request access) to get our shared `treetracker.datasource.json` and `.env` files._
+_**Contact the #admin-panel channel** on Slack (you'll need to request access) to get our shared `.env` files._
 
 ## Development Environment Quick Start
 
@@ -371,13 +371,7 @@ var b = {
 };
 ```
 
-## Credit
-
----
-
-- [Loopback](https://loopback.io/doc/en/lb4/index.html)
-
-## How to contribute
+## Testing
 
 ### For client
 
@@ -391,13 +385,15 @@ To run test:
 
 On server, we used a combination of JS and Typescript, and, because the Loopback would load services/controllers from the typescript output folder (dist), so it get tricky to test.
 
-For the goal of protecting the db, when running test, we will use a separate database. Please put the database datasource file on this location:
+For the goal of protecting the shared development database, when running test, we will use a separate database.
+
+Create a test environment file `server/.env.test` with the test database URL set as follows:
 
 ```
-[project root dir]/server/src/datasources/treetrackerTest.datasource.json
+DATABASE_URL=postgresql://<user>:<password>@<host>:<port>/<database>?ssl=true
 ```
 
-NOTE: please do not set this datasource to point to our dev DB, because the tests would clear all the data in the DB. It would cause trouble if we don't have any data in the dev DB.
+NOTE: Please do not set this URL to point to our development database, because the tests will clear all the data in the database. It would cause trouble if we don't have any data in the dev DB.
 
 To locally install postgresDB, this app might be helpful: https://postgresapp.com/
 
@@ -416,3 +412,7 @@ npm run watch
 In this way, we can write the code and get the tests result immediately.
 
 NOTE: when running tests, the files related to Loopback are loaded from ./dist folder. That's because for Jest, it does not output compiled files at all, and Loopback will try to load the controllers at runtime.
+
+## Credit
+
+- [Loopback](https://loopback.io/doc/en/lb4/index.html)

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -54,8 +54,10 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
+# dotenv environment variables files
 .env
+.env.development
+.env.test
 
 # Transpiled JavaScript files from Typescript
 /dist

--- a/server/package.json
+++ b/server/package.json
@@ -21,11 +21,12 @@
     "posttest": "echo 'Finished running all tests.'",
     "migrate": "node ./dist/migrate",
     "prestart": "npm run clean && npm run build",
-    "start": "DEBUG=loopback:*,express:* node .",
-    "startTest": "NODE_DB=test npm run build && NODE_DB=test DEBUG=loopback:* node ./dist/indexTest.js",
+    "start": "NODE_ENV=development node .",
+    "start:debug": "NODE_ENV=development DEBUG=loopback:*,express:* node .",
+    "startTest": "NODE_ENV=test npm run build && NODE_ENV=test DEBUG=loopback:* node ./dist/indexTest.js",
     "prepublishOnly": "npm run test",
-    "test": "NODE_DB=test jest --watchAll --runInBand",
-    "test:debug": "NODE_DB=test DEBUG=loopback:*,express:* jest --no-cache --watchAll --runInBand",
+    "test": "NODE_ENV=test jest --watchAll --runInBand",
+    "test:debug": "NODE_ENV=test DEBUG=loopback:*,express:* jest --no-cache --watchAll --runInBand",
     "watch": "onchange 'src/controllers/**/*.ts' 'src/models/**/*.ts' 'src/repositories/**/*.ts' -- npm run build"
   },
   "repository": {

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,5 +1,11 @@
 import dotenv from 'dotenv';
+import path from 'path';
+
+// Read universal config
 dotenv.config();
+
+// Read Node environment-specific config
+dotenv.config({path: path.resolve(__dirname, `../.env.${process.env.NODE_ENV}`)});
 
 const config = {
   jwtSecret: process.env.JWT_SECRET,

--- a/server/src/datasources/config.ts
+++ b/server/src/datasources/config.ts
@@ -1,29 +1,20 @@
-//NOTE, here import datasource json is just for Typescript compile purpose,
-//we must import it to let TS cp this json file to the dist folder
-import _ from './treetracker.datasource.json';
-
 export interface DatasourceConfig {
   name: string;
   connector: string;
   url: string;
-  host: string;
-  port: number;
-  user: string;
-  password: string;
-  database: string;
 }
 
-//check the test env, if this is testing, then the NODE_DB=test must be set
-if (process.env.NODE_ENV === 'test' && process.env.NODE_DB !== 'test') {
-  throw new Error("This is test env, please set NODE_DB === 'test'");
+const config: DatasourceConfig = {
+  "name": "treetracker_dev",
+  "connector": "postgresql",
+  "url": process.env.DATABASE_URL || "",
 }
 
-const config: DatasourceConfig =
-  process.env.NODE_DB === 'test'
-    ? require('./treetrackerTest.datasource.json')
-    : require('./treetracker.datasource.json');
+if (!config.url) {
+  console.log(`DATABASE_URL not set - defaulting to localhost:5432`)
+}
 
-function getDatasource(): DatasourceConfig {
+function getDatasource() : DatasourceConfig {
   return config;
 }
 

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -373,7 +373,6 @@ router.post('/init', async (req, res) => {
 
 const isAuth = async (req, res, next) => {
   //white list
-  console.log('testtest');
   const url = req.originalUrl;
   const isDevEnvironment = utils.getEnvironment() === 'development';
   const isApiExplorerReq = isDevEnvironment;


### PR DESCRIPTION
Resolves #436 

The previous mechanism for specifying the database connection (`treetracker.datasource.json`) has been replaced with an environment variable (`DATABASE_URL`) to allow server CI pipeline builds to succeed.

In the development environment, `DATABASE_URL` should be set in `server/.env.development`.
For running tests, the same env var can be set in `server/.env.test`.