### PR TITLE
Allow users to show only trees with no species set

### DIFF
--- a/client/src/api/treeTrackerApi.js
+++ b/client/src/api/treeTrackerApi.js
@@ -10,7 +10,7 @@ export default {
     //the filter model
     filter,
   }) {
-    const where = filter.getBackloopWhere()
+    const where = filter.getWhereObj()
    
     const lbFilter = {
       where,
@@ -122,7 +122,7 @@ export default {
   getTreeCount(filter) {
     const query = `${
       process.env.REACT_APP_API_ROOT
-    }/api/${getOrganization()}trees/count?where=${JSON.stringify(filter.getBackloopWhere())}`
+    }/api/${getOrganization()}trees/count?where=${JSON.stringify(filter.getWhereObj())}`
     console.log(query, session.token)
     return fetch(query, {
       headers: {

--- a/client/src/api/treeTrackerApi.js
+++ b/client/src/api/treeTrackerApi.js
@@ -10,25 +10,29 @@ export default {
     //the filter model
     filter,
   }) {
-    const query =
-      `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees?` +
-      `filter[order]=${orderBy} ${order}&` +
-      `filter[limit]=${rowsPerPage}&` +
-      `filter[skip]=${skip}&` +
-      `filter[fields][imageUrl]=true&` +
-      `filter[fields][lat]=true&` +
-      `filter[fields][lon]=true&` +
-      `filter[fields][id]=true&` +
-      `filter[fields][timeCreated]=true&` +
-      `filter[fields][timeUpdated]=true&` +
-      `filter[fields][active]=true&` +
-      `filter[fields][approved]=true&` +
-      `filter[fields][planterId]=true&` +
-      `filter[fields][deviceId]=true&` +
-      `filter[fields][planterIdentifier]=true&` +
-      `field[imageURL]` +
-      //the filter query
-      filter.getBackloopString()
+    const where = filter.getBackloopWhere()
+   
+    const lbFilter = {
+      where,
+      order: [`${orderBy} ${order}`],
+      limit: rowsPerPage,
+      skip,
+      fields: {
+        imageUrl: true,
+        lat: true,
+        lon: true,
+        id: true,
+        timeCreated: true,
+        timeUpdated: true,
+        active: true,
+        approved: true,
+        planterId: true,
+        deviceId: true,
+        planterIdentifier: true,
+      },
+    }
+    
+    const query = `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees?filter=${JSON.stringify(lbFilter)}`
     return fetch(query, {
       headers: {
         Authorization: session.token,
@@ -118,7 +122,7 @@ export default {
   getTreeCount(filter) {
     const query = `${
       process.env.REACT_APP_API_ROOT
-    }/api/${getOrganization()}trees/count?${filter.getBackloopString(false)}`
+    }/api/${getOrganization()}trees/count?where=${JSON.stringify(filter.getBackloopWhere())}`
     console.log(query, session.token)
     return fetch(query, {
       headers: {

--- a/client/src/components/FilterTop.js
+++ b/client/src/components/FilterTop.js
@@ -5,7 +5,7 @@ import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
 import Autocomplete from '@material-ui/lab/Autocomplete';
-import FilterModel, {ALL_SPECIES, NO_SPECIES} from '../models/Filter';
+import FilterModel, {ALL_SPECIES, SPECIES_NOT_SET} from '../models/Filter';
 import DateFnsUtils from '@date-io/date-fns';
 import {connect} from 'react-redux';
 import {
@@ -13,6 +13,7 @@ import {
   KeyboardDatePicker
 } from '@material-ui/pickers';
 import { getDatePickerLocale, getDateFormatLocale, convertDateToDefaultSqlDate } from '../common/locale'
+import { species } from 'models';
 
 export const FILTER_WIDTH = 330;
 
@@ -46,6 +47,9 @@ const styles = theme => {
     },
     autocompleteInputRoot: {
       padding: `${theme.spacing(0, 12, 0, 1)} !important`,
+    },
+    noSpecies: {
+      fontStyle: 'italic',
     },
   };
 };
@@ -211,9 +215,9 @@ function Filter(props) {
             >
               {[
                 {id:ALL_SPECIES, name:'All'},
-                {id:NO_SPECIES, name:'(none)'},
+                {id:SPECIES_NOT_SET, name:'Not set'},
                 ...props.speciesState.speciesList
-              ].map(species => (
+              ].map((species, idx) => (
                 <MenuItem key={species.id} value={species.id}>
                   {species.name}
                 </MenuItem>

--- a/client/src/components/FilterTop.js
+++ b/client/src/components/FilterTop.js
@@ -13,7 +13,6 @@ import {
   KeyboardDatePicker
 } from '@material-ui/pickers';
 import { getDatePickerLocale, getDateFormatLocale, convertDateToDefaultSqlDate } from '../common/locale'
-import { species } from 'models';
 
 export const FILTER_WIDTH = 330;
 
@@ -217,7 +216,7 @@ function Filter(props) {
                 {id:ALL_SPECIES, name:'All'},
                 {id:SPECIES_NOT_SET, name:'Not set'},
                 ...props.speciesState.speciesList
-              ].map((species, idx) => (
+              ].map(species => (
                 <MenuItem key={species.id} value={species.id}>
                   {species.name}
                 </MenuItem>

--- a/client/src/components/FilterTop.js
+++ b/client/src/components/FilterTop.js
@@ -5,7 +5,7 @@ import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
 import Autocomplete from '@material-ui/lab/Autocomplete';
-import FilterModel from '../models/Filter';
+import FilterModel, {ALL_SPECIES, NO_SPECIES} from '../models/Filter';
 import DateFnsUtils from '@date-io/date-fns';
 import {connect} from 'react-redux';
 import {
@@ -66,7 +66,7 @@ function Filter(props) {
     filter.dateStart || dateStartDefault
   );
   const [dateEnd, setDateEnd] = useState(filter.dateEnd || dateEndDefault);
-  const [speciesId, setSpeciesId] = useState(0);
+  const [speciesId, setSpeciesId] = useState(ALL_SPECIES);
   const [tagId, setTagId] = useState(0);
   const [tagSearchString, setTagSearchString] = useState('');
 
@@ -209,7 +209,11 @@ function Filter(props) {
               value={speciesId}
               onChange={e => setSpeciesId(e.target.value)}
             >
-              {[{id:0,name:'all'}, ...props.speciesState.speciesList].map(species => (
+              {[
+                {id:ALL_SPECIES, name:'All'},
+                {id:NO_SPECIES, name:'(none)'},
+                ...props.speciesState.speciesList
+              ].map(species => (
                 <MenuItem key={species.id} value={species.id}>
                   {species.name}
                 </MenuItem>

--- a/client/src/models/Filter.js
+++ b/client/src/models/Filter.js
@@ -2,6 +2,9 @@
  * A simple model for tree filter
  */
 
+export const ALL_SPECIES = 'ALL_SPECIES'
+export const NO_SPECIES = 'NO_SPECIES'
+
 export default class Filter {
   treeId
   //status
@@ -19,56 +22,63 @@ export default class Filter {
     Object.assign(this, options)
   }
 
-  getBackloopString(includeFilterString = true) {
+  getBackloopWhere() {
     //{{{
-    let result = ''
-    const prefix = includeFilterString ? '&filter[where]' : '&where'
+    let where = {}
 
     if (this.treeId) {
-      result += `${prefix}[id]=${this.treeId}`
+      where.id = this.treeId
     }
 
-    //		if(this.status){
-    //			result		+= `${prefix}[status]=${this.status.toLowerCase()}`
-    //		}
-
     if (this.dateStart && this.dateEnd) {
-      result += `${prefix}[timeCreated][between]=${this.dateStart}${prefix}[timeCreated][between]=${this.dateEnd}`
+      where.timeCreated = {
+        between: [this.dateStart, this.dateEnd]
+      }
     } else if (this.dateStart && !this.dateEnd) {
-      result += `${prefix}[timeCreated][gte]=${this.dateStart}`
+      where.timeCreated = {
+        gte: this.dateStart
+      }
     } else if (!this.dateStart && this.dateEnd) {
-      result += `${prefix}[timeCreated][lte]=${this.dateEnd}`
+      where.timeCreated = {
+        lte: this.dateEnd
+      }
     }
 
     if (this.approved !== undefined) {
-      result += `${prefix}[approved]=${this.approved}`
+      where.approved = this.approved
+    }
+
+    if (this.rejected !== undefined) {
+      where.rejected = this.rejected
     }
 
     if (this.active !== undefined) {
-      result += `${prefix}[active]=${this.active}`
+      where.active = this.active
     }
 
     if (this.planterId !== undefined && this.planterId.length > 0) {
-      result += `${prefix}[planterId]=${this.planterId}`
+      where.planterId = this.planterId
     }
 
     if (this.deviceId !== undefined && this.deviceId.length > 0) {
-      result += `${prefix}[deviceId]=${this.deviceId}`
+      where.deviceId = this.deviceId
     }
 
     if (this.planterIdentifier !== undefined && this.planterIdentifier.length > 0) {
-      result += `${prefix}[planterIdentifier]=${this.planterIdentifier}`
+      where.planterIdentifier = this.planterIdentifier
     }
 
-    if (this.speciesId) {
-      result += `${prefix}[speciesId]=${this.speciesId}`
+    if (this.speciesId === NO_SPECIES) {
+      where.speciesId = null
+    } else if (this.speciesId !== ALL_SPECIES) {
+      where.speciesId = this.speciesId
     }
-
+ 
     if (this.tagId) {
-      result += `${prefix}[tagId]=${this.tagId}`
+      where.tagId = this.tagId
     }
 
-    return result
+    return where
     //}}}
   }
 

--- a/client/src/models/Filter.js
+++ b/client/src/models/Filter.js
@@ -22,7 +22,7 @@ export default class Filter {
     Object.assign(this, options)
   }
 
-  getBackloopWhere() {
+  getWhereObj() {
     //{{{
     let where = {}
 

--- a/client/src/models/Filter.js
+++ b/client/src/models/Filter.js
@@ -3,7 +3,7 @@
  */
 
 export const ALL_SPECIES = 'ALL_SPECIES'
-export const NO_SPECIES = 'NO_SPECIES'
+export const SPECIES_NOT_SET = 'SPECIES_NOT_SET'
 
 export default class Filter {
   treeId
@@ -68,7 +68,7 @@ export default class Filter {
       where.planterIdentifier = this.planterIdentifier
     }
 
-    if (this.speciesId === NO_SPECIES) {
+    if (this.speciesId === SPECIES_NOT_SET) {
       where.speciesId = null
     } else if (this.speciesId !== ALL_SPECIES) {
       where.speciesId = this.speciesId

--- a/client/src/models/Filter.test.js
+++ b/client/src/models/Filter.test.js
@@ -1,41 +1,35 @@
-import Filter		from './Filter'
+import Filter from './Filter'
 
 describe('Filter, with initial values about this filter object', () => {
 	let filter
 
 	beforeEach(() => {
-		filter		= new Filter()
-		filter.treeId		= 10
-		filter.status		= 'Planted'
-		filter.dateStart		= '2019-07-25'
-		filter.dateEnd		= '2019-07-30'
-		filter.approved		= true
-		filter.active		= true
-		filter.planterId		= '1'
-		filter.deviceId		= '1'
-		filter.planterIdentifier		= '1'
+		filter = new Filter()
+		filter.treeId = 10
+		filter.dateStart = '2019-07-25'
+		filter.dateEnd = '2019-07-30'
+		filter.approved = true
+		filter.active	= true
+		filter.planterId = '1'
+		filter.deviceId = '1'
+		filter.planterIdentifier = '1'
 	})
 
-	it('getBackloopString() should be: ', () => {
-		console.log(filter.getBackloopString())
-		expect(filter.getBackloopString()).toEqual(expect.stringContaining('&filter[where][id]=10'))
-		expect(filter.getBackloopString()).toEqual(expect.not.stringContaining('&filter[where][status]=planted'))
-		expect(filter.getBackloopString()).toEqual(expect.stringContaining('&filter[where][timeCreated][between]=2019-07-25&filter[where][timeCreated][between]=2019-07-30'))
+	it('getWhereObj() should be: ', () => {
+		console.log(filter.getWhereObj())
+		expect(filter.getWhereObj()).toEqual(expect.objectContaining({id: 10}))
 	})
 
-	it('getBackloopString(false) should be: ', () => {
-		console.log(filter.getBackloopString(false))
-		expect(filter.getBackloopString(false)).toEqual(expect.stringContaining('&where[id]=10'))
-		expect(filter.getBackloopString(false)).toEqual(expect.not.stringContaining('&where[status]=planted'))
-		expect(filter.getBackloopString(false)).toEqual(expect.stringContaining('&where[timeCreated][between]=2019-07-25&where[timeCreated][between]=2019-07-30'))
+	it('getWhereObj() should match: timeCreated between', () => {
+		expect(filter.getWhereObj()).toEqual(expect.objectContaining({timeCreated: {between: ['2019-07-25', '2019-07-30']}}))
 	})
 
-	it('getBackloopString() should match: approved=true', () => {
-		expect(filter.getBackloopString().indexOf('&filter[where][approved]=true') >= 0).toBe(true)
+	it('getWhereObj() should match: approved=true', () => {
+		expect(filter.getWhereObj()).toEqual(expect.objectContaining({approved: true}))
 	})
 
-	it('getBackloopString() should match: active=true', () => {
-		expect(filter.getBackloopString().indexOf('&filter[where][active]=true') >= 0).toBe(true)
+	it('getWhereObj() should match: active=true', () => {
+		expect(filter.getWhereObj()).toEqual(expect.objectContaining({active: true}))
 	})
 
 	describe('change approved = false', () => {
@@ -44,23 +38,23 @@ describe('Filter, with initial values about this filter object', () => {
 			filter.approved		= false
 		})
 
-		it('getBackloopString() should be approved=false', () => {
-			expect(filter.getBackloopString().indexOf('&filter[where][approved]=false') >= 0).toBe(true)
+		it('getWhereObj() should be approved=false', () => {
+			expect(filter.getWhereObj()).toEqual(expect.objectContaining({approved: false}))
 		})
 
 		//}}}
 	})
 
-	it('getBackloopString() should match: planterId=1', () => {
-		expect(filter.getBackloopString().indexOf('&filter[where][planterId]=1') >= 0).toBe(true)
+	it('getWhereObj() should match: planterId=1', () => {
+		expect(filter.getWhereObj()).toEqual(expect.objectContaining({planterId: '1'}))
 	})
 
-	it('getBackloopString() should match: deviceId=1', () => {
-		expect(filter.getBackloopString().indexOf('&filter[where][deviceId]=1') >= 0).toBe(true)
+	it('getWhereObj() should match: deviceId=1', () => {
+		expect(filter.getWhereObj()).toEqual(expect.objectContaining({deviceId: '1'}))
 	})
 
-	it('getBackloopString() should match: planterIdentifier=1', () => {
-		expect(filter.getBackloopString().indexOf('&filter[where][planterIdentifier]=1') >= 0).toBe(true)
+	it('getWhereObj() should match: planterIdentifier=1', () => {
+		expect(filter.getWhereObj()).toEqual(expect.objectContaining({planterIdentifier: '1'}))
 	})
 
 	describe('set treeId = ""', () => {
@@ -69,8 +63,8 @@ describe('Filter, with initial values about this filter object', () => {
 			filter.treeId		= ''
 		})
 
-		it('backloop string should not match any [id]', () => {
-			expect(filter.getBackloopString().indexOf('[id]') < 0).toBe(true)
+		it('loopback object should not match any [id]', () => {
+			expect(filter.getWhereObj()).not.toHaveProperty('id')
 		})
 		//}}}
 	})
@@ -81,9 +75,9 @@ describe('Filter, with initial values about this filter object', () => {
 			filter.planterId		= ''
 		})
 
-		it('backloop string should not match any [planterId]', () => {
-			console.error('the where:', filter.getBackloopString())
-			expect(filter.getBackloopString().indexOf('[planterId]') < 0).toBe(true)
+		it('loopback object should not match any [planterId]', () => {
+			console.error('the where:', filter.getWhereObj())
+			expect(filter.getWhereObj()).not.toHaveProperty('planterId')
 		})
 		//}}}
 	})
@@ -94,8 +88,8 @@ describe('Filter, with initial values about this filter object', () => {
 			filter.deviceId		= ''
 		})
 
-		it('backloop string should not match any deviceId', () => {
-			expect(filter.getBackloopString().indexOf('deviceId') < 0).toBe(true)
+		it('loopback object should not match any deviceId', () => {
+			expect(filter.getWhereObj()).not.toHaveProperty('deviceId')
 		})
 		//}}}
 	})
@@ -106,8 +100,8 @@ describe('Filter, with initial values about this filter object', () => {
 			filter.planterIdentifier		= ''
 		})
 
-		it('backloop string should not match any planterIdentifier', () => {
-			expect(filter.getBackloopString().indexOf('planterIdentifier') < 0).toBe(true)
+		it('loopback object should not match any planterIdentifier', () => {
+			expect(filter.getWhereObj()).not.toHaveProperty('planterIdentifier')
 		})
 		//}}}
 	})
@@ -119,8 +113,8 @@ describe('Filter, with initial values about this filter object', () => {
 		})
 
 		it('should be lte', () => {
-			console.log(filter.getBackloopString())
-			expect(filter.getBackloopString().indexOf('&filter[where][timeCreated][lte]=2019-07-30') >=0).toBe(true)
+			console.log(filter.getWhereObj())
+			expect(filter.getWhereObj()).toEqual(expect.objectContaining({timeCreated: {lte: '2019-07-30'}}))
 		})
 		//}}}
 	})
@@ -132,8 +126,8 @@ describe('Filter, with initial values about this filter object', () => {
 		})
 
 		it('should be gte', () => {
-			console.log(filter.getBackloopString())
-			expect(filter.getBackloopString().indexOf('&filter[where][timeCreated][gte]=2019-07-25') >=0).toBe(true)
+			console.log(filter.getWhereObj())
+			expect(filter.getWhereObj()).toEqual(expect.objectContaining({timeCreated: {gte: '2019-07-25'}}))
 		})
 		//}}}
 	})

--- a/client/src/models/Filter.test.js
+++ b/client/src/models/Filter.test.js
@@ -16,7 +16,6 @@ describe('Filter, with initial values about this filter object', () => {
 	})
 
 	it('getWhereObj() should be: ', () => {
-		console.log(filter.getWhereObj())
 		expect(filter.getWhereObj()).toEqual(expect.objectContaining({id: 10}))
 	})
 
@@ -113,7 +112,6 @@ describe('Filter, with initial values about this filter object', () => {
 		})
 
 		it('should be lte', () => {
-			console.log(filter.getWhereObj())
 			expect(filter.getWhereObj()).toEqual(expect.objectContaining({timeCreated: {lte: '2019-07-30'}}))
 		})
 		//}}}
@@ -126,7 +124,6 @@ describe('Filter, with initial values about this filter object', () => {
 		})
 
 		it('should be gte', () => {
-			console.log(filter.getWhereObj())
 			expect(filter.getWhereObj()).toEqual(expect.objectContaining({timeCreated: {gte: '2019-07-25'}}))
 		})
 		//}}}

--- a/client/src/models/trees.js
+++ b/client/src/models/trees.js
@@ -103,7 +103,7 @@ const trees = {
       this.invalidateTreeCount(false);
       let response = await Axios.get(
         `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees/count?
-         where=${JSON.stringify(filter ? filter.getBackloopWhere(): {})}`,
+         where=${JSON.stringify(filter ? filter.getWhereObj(): {})}`,
         {
           headers: {
             'content-type': 'application/json',
@@ -128,7 +128,7 @@ const trees = {
 
       let response = await Axios.get(
         `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees/count?
-         where=${JSON.stringify(filter ? filter.getBackloopWhere(): {})}`,
+         where=${JSON.stringify(filter ? filter.getWhereObj(): {})}`,
         {
           headers: {
             'content-type': 'application/json',
@@ -139,7 +139,7 @@ const trees = {
       const data = response.data
       this.receiveTreeCount(data)
 
-      const where = filter ? filter.getBackloopWhere() : {}
+      const where = filter ? filter.getWhereObj() : {}
    
       const lbFilter = JSON.stringify({
         where: {...where, active: true},

--- a/client/src/models/trees.js
+++ b/client/src/models/trees.js
@@ -102,8 +102,8 @@ const trees = {
 
       this.invalidateTreeCount(false);
       let response = await Axios.get(
-        `${process.env.REACT_APP_API_ROOT}/api/trees/count?` +
-          (filter ? filter.getBackloopString(false) : ''),
+        `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees/count?
+         where=${JSON.stringify(filter ? filter.getBackloopWhere(): {})}`,
         {
           headers: {
             'content-type': 'application/json',
@@ -127,8 +127,8 @@ const trees = {
       }
 
       let response = await Axios.get(
-        `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees/count?` +
-          (filter ? filter.getBackloopString(false) : ''),
+        `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees/count?
+         where=${JSON.stringify(filter ? filter.getBackloopWhere(): {})}`,
         {
           headers: {
             'content-type': 'application/json',
@@ -139,14 +139,24 @@ const trees = {
       const data = response.data
       this.receiveTreeCount(data)
 
-      const query =
-        `${
-          process.env.REACT_APP_API_ROOT
-        }/api/${getOrganization()}trees?filter[order]=${orderBy} ${order}&filter[limit]=${rowsPerPage}&filter[skip]=${
-          page * rowsPerPage
-        }&filter[fields][id]=true&filter[fields][timeCreated]=true&filter[fields][status]=true` +
-        `&filter[fields][planterId]=true&filter[fields][treeTags]=true&filter[where][active]=true` +
-        (filter ? filter.getBackloopString() : '')
+      const where = filter ? filter.getBackloopWhere() : {}
+   
+      const lbFilter = JSON.stringify({
+        where: {...where, active: true},
+        order: [`${orderBy} ${order}`],
+        limit: rowsPerPage,
+        skip: page * rowsPerPage,
+        fields: {
+          id: true,
+          timeCreated: true,
+          status: true,
+          planterId: true,
+          treeTags: true,
+        },
+      })
+      
+      const query = `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees?filter=${JSON.stringify(lbFilter)}`
+                
       response = await Axios.get(query, {
         headers: {
           'content-type': 'application/json',


### PR DESCRIPTION
Resolves #428 

Selecting _Not set_ from the Species dropdown in the Verify page filter will show only trees whose species has not been set.

This required switching tree requests to the Loopback JSON object format.

![Screenshot 2020-11-15 at 15 45 27](https://user-images.githubusercontent.com/5558838/99189557-96c50900-2759-11eb-8386-a961de7c6f39.png)
