### PR TITLE
Bugfix/418 admin user delete

### DIFF
--- a/client/src/components/Users.js
+++ b/client/src/components/Users.js
@@ -639,7 +639,9 @@ function Users(props) {
               value={(userEditing && userEditing.enabled ? ENABLED : DISABLED)}
               onChange={handleStatusChange}
               >
-              {[ENABLED, DISABLED].map(val => <FormControlLabel value={val} control={<Radio />} label={val} />)}
+              {[ENABLED, DISABLED].map(val =>
+                <FormControlLabel key={val} value={val} control={<Radio />} label={val} />
+              )}
             </RadioGroup>
           </FormControl>
           {userEditing && userEditing.createdAt && (

--- a/client/src/components/Users.js
+++ b/client/src/components/Users.js
@@ -400,7 +400,14 @@ function Users(props) {
   }
 
   function handleAddUser() {
-    setUserEditing({active: true, enabled: true})
+    setUserEditing({
+      userName: '',
+      firstName: '',
+      lastName: '',
+      email: '',
+      active: true,
+      enabled: true,
+    })
     setLeft(permissions)
   }
 

--- a/client/src/components/Users.js
+++ b/client/src/components/Users.js
@@ -199,6 +199,7 @@ function Users(props) {
         }
       )
       if (res.status === 204) {
+        showSnackbar(`${userDelete.userName} successfully deleted`)
         setUserDelete(undefined)
         setErrorMessage('')
         load()
@@ -470,7 +471,7 @@ function Users(props) {
           <IconButton title="edit" onClick={() => handleEdit(user)}>
             <Edit />
           </IconButton>
-          <IconButton title="delete" onclick={() => handleDelete(user)}>
+          <IconButton title="delete" onClick={() => handleDelete(user)}>
             <Delete />
           </IconButton>
           <IconButton title="change password" onClick={() => handleChangePassword(user)}>

--- a/client/src/components/Users.js
+++ b/client/src/components/Users.js
@@ -187,7 +187,7 @@ function Users(props) {
   }
 
   async function handleDeleteConfirm() {
-    if (userDelete.id == user.id) {
+    if (userDelete.id === user.id) {
       setErrorMessage('Cannot delete active user.')
       return
     }
@@ -470,7 +470,7 @@ function Users(props) {
           <IconButton title="edit" onClick={() => handleEdit(user)}>
             <Edit />
           </IconButton>
-          <IconButton>
+          <IconButton title="delete" onclick={() => handleDelete(user)}>
             <Delete />
           </IconButton>
           <IconButton title="change password" onClick={() => handleChangePassword(user)}>

--- a/client/src/components/Users.js
+++ b/client/src/components/Users.js
@@ -639,8 +639,7 @@ function Users(props) {
               value={(userEditing && userEditing.enabled ? ENABLED : DISABLED)}
               onChange={handleStatusChange}
               >
-              <FormControlLabel value={ENABLED} control={<Radio />} label={ENABLED} />
-              <FormControlLabel value={DISABLED} control={<Radio />} label={DISABLED} />
+              {[ENABLED, DISABLED].map(val => <FormControlLabel value={val} control={<Radio />} label={val} />)}
             </RadioGroup>
           </FormControl>
           {userEditing && userEditing.createdAt && (

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -247,9 +247,9 @@ router.get('/admin_users/', async (req, res) => {
     let result = await pool.query(`select * from admin_user where active = true`);
     const users = [];
     for (let i = 0; i < result.rows.length; i++) {
+      const user = result.rows[i];
       delete user.password_hash;
       delete user.salt;
-      const user = result.rows[i];
       const roles = await getActiveAdminUserRoles(user.id)
       user.role = roles.rows.map(rr => rr.role_id);
       users.push(utils.convertCamel(user));
@@ -298,6 +298,10 @@ router.post('/admin_users/', async (req, res) => {
     //active
     if (req.body.active == undefined) {
       req.body.active = true;
+    }
+    //enabled
+    if (req.body.enabled == undefined) {
+      req.body.enabled = true;
     }
     const insert = `insert into admin_user ${utils.buildInsertFields(
       req.body,

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -83,7 +83,7 @@ async function deactivateAdminUser(userId) {
   return await pool.query(`update admin_user set active = false where id = ${userId}`);
 }
 
-router.get('/permissions', async function login(req, res, next) {
+router.get('/permissions', async function login(req, res) {
   try {
     const result = await pool.query(`select * from admin_role`);
     res.status(200).json(result.rows.map((r) => utils.convertCamel(r)));
@@ -100,7 +100,7 @@ router.post('/login', async function login(req, res, next) {
     const {userName, password} = req.body;
 
     //find the user to get the salt, validate if hashed password matches
-    let users = await getActiveAdminUser(userName);
+    const users = await getActiveAdminUser(userName);
 
     let userLogin;
     if (users.rows.length) {
@@ -244,7 +244,7 @@ router.delete('/admin_users/:userId', async (req, res) => {
 
 router.get('/admin_users/', async (req, res) => {
   try {
-    let result = await pool.query(`select * from admin_user where active = true`);
+    const result = await pool.query(`select * from admin_user where active = true`);
     const users = [];
     for (let i = 0; i < result.rows.length; i++) {
       const user = result.rows[i];
@@ -413,7 +413,7 @@ const isAuth = async (req, res, next) => {
     if (url.match(/\/auth\/check_session/)) {
       const user_id = req.query.id;
       console.log(user_id);
-      let result = await getActiveAdminUserRoles(user_id);
+      const result = await getActiveAdminUserRoles(user_id);
       if (result.rows.length === 1) {
         const update_userSession = utils.convertCamel(result.rows[0]);
         //compare wuth the updated pwd in case pwd is changed

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -43,8 +43,13 @@ const generateSalt = function () {
 const jsonParser = app.use(bodyParser.urlencoded({extended: false})); // parse application/json
 // const urlencodedParser = app.use(bodyParser.json());/// parse application/x-www-form-urlencoded
 
+function isIdValid(id) {
+  // an ID is valid if it is not null or undefined
+  return id != null
+}
+
 async function getActiveAdminUserRoles(userId) {
-  if (userId == null) {
+  if (!isIdValid(userId)) {
     return null
   }
   return await pool.query(
@@ -53,7 +58,7 @@ async function getActiveAdminUserRoles(userId) {
 }
 
 async function clearAdminUserRoles(userId) {
-  if (userId == null) {
+  if (!isIdValid(userId)) {
     return
   }
   return await pool.query(
@@ -62,11 +67,14 @@ async function clearAdminUserRoles(userId) {
 }
 
 async function addAdminUserRole(userId, roleId) {
-  if (userId == null || roleId == null) {
+  if (!isIdValid(userId) || !isIdValid(roleId)) {
     return
   }
   return await pool.query(
-    `insert into admin_user_role (role_id, admin_user_id, active) values (${roleId},${userId},true) on conflict (role_id, admin_user_id) do update set active = true`,
+    `insert into admin_user_role (role_id, admin_user_id, active)
+     values (${roleId},${userId},true)
+     on conflict (role_id, admin_user_id)
+     do update set active = true`,
   )
 }
 
@@ -77,7 +85,7 @@ async function getActiveAdminUser(userName) {
 }
 
 async function deactivateAdminUser(userId) {
-  if (userId == null) {
+  if (!isIdValid(userId)) {
     return
   }
   return await pool.query(`update admin_user set active = false where id = ${userId}`);

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -327,7 +327,7 @@ router.post('/admin_users/', async (req, res, next) => {
     req.body.passwordHash = req.body.password;
     delete req.body.password;
     let result = await getActiveAdminUser(req.body.userName)
-    if (result.rows.length === 1) {
+    if (result.rows.length) {
       //TODO 401
       res.status(201).json({id: result.rows[0].id});
       return;
@@ -341,11 +341,9 @@ router.post('/admin_users/', async (req, res, next) => {
     )}`;
     console.log('insert:', insert);
     await pool.query(insert);
-    result = await pool.query(
-      `select * from admin_user where user_name = '${req.body.userName}' and active = true`,
-    );
+    result = await getActiveAdminUser(req.body.userName);
     let obj;
-    if (result.rows.length === 1) {
+    if (result.rows.length) {
       obj = result.rows[0];
       //roles
       //role

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -114,13 +114,13 @@ router.post('/login', async function login(req, res, next) {
         const result = await getActiveAdminUserRoles(userLogin.id)
         userLogin.role = result.rows.map(r => r.role_id);
       }
-    }else{
+    } else {
       console.log("can not find user by ", userName);
     }
 
     // If user exists in db AND user is active
     // query remaining details and return
-    if (userLogin && userLogin.active) {
+    if (userLogin && userLogin.enabled) {
       const userDetails = await loadUserPermissions(userLogin.id);
       userLogin = {...userLogin, ...userDetails};
       //TODO get user

--- a/server/src/models/adminUser.model.ts
+++ b/server/src/models/adminUser.model.ts
@@ -69,6 +69,26 @@ export class AdminUser extends Entity {
   })
   email?: String;
 
+  @property({
+    type: Boolean,
+    required: true,
+    postgresql: {
+      columnName: 'active',
+      dataType: 'boolean',
+    },
+  })
+  active?: Boolean;
+
+  @property({
+    type: Boolean,
+    required: true,
+    postgresql: {
+      columnName: 'enabled',
+      dataType: 'boolean',
+    },
+  })
+  enabled?: Boolean;
+
   // Define well-known properties here
 
   // Indexer property to allow additional data


### PR DESCRIPTION
Resolves #418 
To be deployed in conjunction with Greenstand/treetracker-database#50

- Replaced _Active_ and _Inactive_ user status with _Enabled_ and _Disabled_
- Improved New/Edit User UI
- Set `active=false` when user delete is requested
- Only return users where `active=true`
- Refactored `auth.js` to reduce code duplication