### PR TITLE
Show appropriate messages when users navigate to unauthorized or non-existent pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ coverage
 node_modules
 npm-debug.log
 server/server/config/datasources.json
+server/.env

--- a/client/src/components/Context.js
+++ b/client/src/components/Context.js
@@ -21,6 +21,7 @@ import HomeIcon from '@material-ui/icons/Home'
 
 import { session, hasPermission, POLICIES } from '../models/auth'
 import axios from 'axios'
+import Unauthorized from './Unauthorized'
 
 export const AppContext = React.createContext({})
 
@@ -36,7 +37,7 @@ function getRoutes(user) {
     },
     {
       name: 'Monitor',
-      linkTo: '/',
+      linkTo: '/monitor',
       icon: IconShowChart,
       disabled: true,
     },
@@ -76,7 +77,7 @@ function getRoutes(user) {
     },
     {
       name: 'Payments',
-      linkTo: '/',
+      linkTo: '/payments',
       icon: IconCompareArrows,
       disabled: true,
     },
@@ -94,7 +95,8 @@ function getRoutes(user) {
     },
     {
       name: 'Settings',
-      linkTo: '/',
+      linkTo: '/settings',
+      component: Unauthorized,
       icon: IconSettings,
       disabled: true,
     },
@@ -180,6 +182,9 @@ export const AppProvider = (props) => {
           localStorage.setItem('token', JSON.stringify(newToken))
         }
       }
+    },
+    isLoggedIn: () => {
+      return !!user && !!token;
     },
     logout: () => {
       setUser(undefined)

--- a/client/src/components/Context.js
+++ b/client/src/components/Context.js
@@ -117,7 +117,7 @@ function getRoutes(user) {
       icon: IconPermIdentity,
       disabled: false,
     },
-  ].filter(({disabled}) => !disabled)
+  ]
 }
 
 export const AppProvider = (props) => {
@@ -182,9 +182,6 @@ export const AppProvider = (props) => {
           localStorage.setItem('token', JSON.stringify(newToken))
         }
       }
-    },
-    isLoggedIn: () => {
-      return !!user && !!token;
     },
     logout: () => {
       setUser(undefined)

--- a/client/src/components/GenericMessagePage.js
+++ b/client/src/components/GenericMessagePage.js
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import Grid from '@material-ui/core/Grid'
 import Paper from '@material-ui/core/Paper'
 import { withStyles } from '@material-ui/core/styles'
 
@@ -38,7 +37,8 @@ const style = (theme) => ({
   },
   text: {
     fontSize: '40px',
-    alignSelf: 'center'
+    alignSelf: 'center',
+    textAlign: 'center',
   }
 })
 

--- a/client/src/components/GenericMessagePage.js
+++ b/client/src/components/GenericMessagePage.js
@@ -1,0 +1,60 @@
+import React from 'react'
+
+import Grid from '@material-ui/core/Grid'
+import Paper from '@material-ui/core/Paper'
+import { withStyles } from '@material-ui/core/styles'
+
+import Menu, { MENU_WIDTH } from './common/Menu'
+
+const style = (theme) => ({
+  box: {
+    width: '100%',
+    height: '100%',
+    position: 'relative',
+  },
+  menuAside: {
+    height: '100%',
+    width: MENU_WIDTH,
+    position: 'absolute',
+    left: 0,
+    top: 0
+  },
+  menu: {
+    height: '100%',
+    width: MENU_WIDTH,
+    overflow: 'hidden'
+  },
+  rightBox: {
+    height: '100%',
+    position: 'absolute',
+    padding: '40px',
+    left: MENU_WIDTH,
+    top: 0,
+    right: 0,
+    backgroundColor: 'rgb(239, 239, 239)',
+    boxSizing: 'border-box',
+    display: 'flex',
+    justifyContent: 'center'
+  },
+  text: {
+    fontSize: '40px',
+    alignSelf: 'center'
+  }
+})
+
+function GenericMessagePage({ classes, text }) {
+  return (
+    <div className={classes.box}>
+      <div className={classes.menuAside}>
+        <Paper elevation={3} className={classes.menu}>
+          <Menu variant="plain" />
+        </Paper>
+      </div>
+      <div className={classes.rightBox}>
+        <span className={classes.text}>{ text }</span>
+      </div>
+    </div>
+  );
+}
+
+export default withStyles(style)(GenericMessagePage);

--- a/client/src/components/Page404.js
+++ b/client/src/components/Page404.js
@@ -2,4 +2,4 @@ import React from 'react'
 
 import GenericMessagePage from './GenericMessagePage'
 
-export default () => (<GenericMessagePage text="404 Not Found"/>)
+export default () => (<GenericMessagePage text="404 Page Not Found :("/>)

--- a/client/src/components/Page404.js
+++ b/client/src/components/Page404.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+import GenericMessagePage from './GenericMessagePage'
+
+export default () => (<GenericMessagePage text="404 Not Found"/>)

--- a/client/src/components/Routers.js
+++ b/client/src/components/Routers.js
@@ -4,6 +4,8 @@ import Grid from '@material-ui/core/Grid'
 import Login from './Login'
 import { AppContext } from './Context'
 import PrivateRoute from './PrivateRoute'
+import Unauthorized from './Unauthorized'
+import Page404 from './Page404'
 
 export default function Routers() {
   const refContainer = React.useRef()
@@ -31,10 +33,10 @@ export default function Routers() {
                 <Login />
               </Route>
               { appContext.routes
-                .map(({linkTo, exact = false, component}, idx) => (
+                .map(({linkTo, exact = false, component, disabled}, idx) => (
                   <PrivateRoute
                     path={linkTo}
-                    component={component}
+                    component={disabled ? Unauthorized : component}
                     exact={exact}
                     getScrollContainerRef={linkTo === '/verify' ? () => refContainer.current : undefined}
                     key={`route_${idx}`}
@@ -43,10 +45,11 @@ export default function Routers() {
               }
               <Route
                 render={({location}) => (
-                  <Redirect to={{
-                    pathname: appContext.user ? "/" : "/login",
+                  appContext.isLoggedIn() ? (Page404) :
+                  (<Redirect to={{
+                    pathname: "/login",
                     state: { from: location }
-                  }}/>
+                  }}/>)
                 )}
               />
             </Switch>

--- a/client/src/components/Routers.js
+++ b/client/src/components/Routers.js
@@ -44,13 +44,15 @@ export default function Routers() {
                 ))
               }
               <Route
-                render={({location}) => (
-                  appContext.isLoggedIn() ? (Page404) :
-                  (<Redirect to={{
-                    pathname: "/login",
-                    state: { from: location }
-                  }}/>)
-                )}
+                render={
+                  appContext.user ? (Page404) :
+                  ({location}) => (
+                    <Redirect to={{
+                      pathname: "/login",
+                      state: { from: location }
+                    }}/>
+                  )
+                }
               />
             </Switch>
           </Grid>

--- a/client/src/components/Unauthorized.js
+++ b/client/src/components/Unauthorized.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+import GenericMessagePage from './GenericMessagePage'
+
+export default () => (<GenericMessagePage text="You are not authorized to view this page"/>)

--- a/client/src/components/common/Menu.js
+++ b/client/src/components/common/Menu.js
@@ -68,7 +68,10 @@ export default function GSMenu(props) {
         <IconLogo />
       </Box>
       <Box height={20} />
-      {React.useMemo(() => (appContext.routes.map((item, i) => (
+      {React.useMemo(() => (
+        appContext.routes
+          .filter(({disabled}) => !disabled)
+          .map((item, i) => (
           <Link
             key={`menu_${i}`}
             className={classes.linkItemText + (item.disabled ? ' ' + classes.disabledLinkItem : '')}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "treetracker-admin",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1
 }


### PR DESCRIPTION
Resolves #410 

Instead of redirecting to `/` when an incorrect route is entered, the user is given the appropriate 401 or 404 landing page.

![Screenshot 2020-12-07 at 20 48 11](https://user-images.githubusercontent.com/5558838/101404548-afdf5680-38ce-11eb-88a9-4a6739466a0e.png)
![Screenshot 2020-12-07 at 20 48 36](https://user-images.githubusercontent.com/5558838/101404552-b1a91a00-38ce-11eb-9306-207b1e765aa6.png)
