### PR TITLE
feat: edit planter

### DIFF
--- a/client/src/api/planters.js
+++ b/client/src/api/planters.js
@@ -73,4 +73,42 @@ export default {
       .then(handleResponse)
       .catch(handleError)
   },
+
+  getPlanterSelfies(planterId) {
+    // TODO: Add planterPhotoUrl not null to query
+    const treeQuery = 
+      `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees/?`+
+      `filter[order]=timeUpdated DESC&` +
+      `filter[limit]=100&`+
+      `filter[fields][planterPhotoUrl]=true&`+
+      `filter[where][planterId]=${planterId}`;
+
+     return fetch(treeQuery, {
+       method: 'GET',
+       headers: { 
+        "content-type": "application/json" ,
+        Authorization: session.token ,
+      },
+    })
+      .then(handleResponse)
+      .then((items) => {
+        return items.map(tree => tree.planterPhotoUrl)
+      })
+      .catch(handleError)
+  },
+
+  updatePlanter(id, planterUpdate) {
+    const planterQuery = `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}planter/${id}`;
+
+    return fetch(planterQuery, {
+      method: "PATCH",
+      headers: { 
+        "content-type": "application/json" ,
+        Authorization: session.token ,
+      },
+      body: JSON.stringify({...planterUpdate, id}),
+    })
+      .then(handleResponse)
+      .catch(handleError);
+  },
 };

--- a/client/src/api/planters.js
+++ b/client/src/api/planters.js
@@ -75,13 +75,15 @@ export default {
   },
 
   getPlanterSelfies(planterId) {
-    // TODO: Add planterPhotoUrl not null to query
+    const filter = {
+      order: 'timeUpdated DESC',
+      limit: 100,
+      fields: ['planterPhotoUrl'],
+      where: { planterId, planterPhotoUrl: { neq: null } }
+    }
+
     const treeQuery = 
-      `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees/?`+
-      `filter[order]=timeUpdated DESC&` +
-      `filter[limit]=100&`+
-      `filter[fields][planterPhotoUrl]=true&`+
-      `filter[where][planterId]=${planterId}`;
+      `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}trees/?filter=${JSON.stringify(filter)}`
 
      return fetch(treeQuery, {
        method: 'GET',
@@ -98,7 +100,8 @@ export default {
       .catch(handleError)
   },
 
-  updatePlanter(id, planterUpdate) {
+  updatePlanter(planterUpdate) {
+    const { id } = planterUpdate;
     const planterQuery = `${process.env.REACT_APP_API_ROOT}/api/${getOrganization()}planter/${id}`;
 
     return fetch(planterQuery, {
@@ -107,7 +110,7 @@ export default {
         "content-type": "application/json" ,
         Authorization: session.token ,
       },
-      body: JSON.stringify({...planterUpdate, id}),
+      body: JSON.stringify(planterUpdate),
     })
       .then(handleResponse)
       .catch(handleError);

--- a/client/src/api/planters.js
+++ b/client/src/api/planters.js
@@ -92,7 +92,8 @@ export default {
     })
       .then(handleResponse)
       .then((items) => {
-        return items.map(tree => tree.planterPhotoUrl)
+        // Remove duplicates
+        return [...new Set(items.map(tree => tree.planterPhotoUrl))]
       })
       .catch(handleError)
   },

--- a/client/src/components/EditPlanter.js
+++ b/client/src/components/EditPlanter.js
@@ -1,4 +1,5 @@
-import React, {useState, useEffect} from 'react'
+import React, { useState, useEffect } from 'react'
+import { connect } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
 import {
   Button,
@@ -59,13 +60,14 @@ const useStyle = makeStyles(theme => ({
     right: 0,
   },
   textInput: {
-    margin: theme.spacing()
+    margin: theme.spacing(),
+    flexGrow: 1,
   },
 }));
 
 const MAX_IMAGES_INCREMENT = 20
 
-function EditPlanter(props) {
+const EditPlanter = (props) => {
   
   const classes = useStyle()
   const { isOpen, planter, onClose } = props
@@ -99,7 +101,7 @@ function EditPlanter(props) {
     if (planterUpdate) {
       setSaveInProgress(true)
       // TODO handle errors
-      await api.updatePlanter(planter.id, planterUpdate)
+      await props.plantersDispatch.updatePlanter({id: planter.id, ...planterUpdate})
       setSaveInProgress(false)
     }
     onClose()
@@ -154,7 +156,6 @@ function EditPlanter(props) {
             <ChevronRight />
           </Fab> */}
           <Grid item container direction="row">
-            <Grid item>
               <TextField
                 className={classes.textInput}
                 id="firstName"
@@ -167,8 +168,6 @@ function EditPlanter(props) {
                 onChange={(e) => {handleChange('firstName', e.target.value)}}
                 value={planterUpdate?.firstName || planter.firstName}
               />
-            </Grid>
-            <Grid item>
               <TextField
                 className={classes.textInput}
                 id="lastName"
@@ -181,7 +180,6 @@ function EditPlanter(props) {
                 onChange={(e) => {handleChange('lastName', e.target.value)}}
                 value={planterUpdate?.lastName || planter.lastName}
               />
-            </Grid>
           </Grid>
         </Grid>
       </DialogContent>
@@ -189,12 +187,21 @@ function EditPlanter(props) {
         <Button onClick={handleCancel}>
           Cancel
         </Button>
-        <Button onClick={handleSave} variant="contained" color="primary" disabled={!planterUpdate || saveInProgress}>
+        <Button onClick={handleSave} variant="contained" color="primary"
+                disabled={!planterUpdate || saveInProgress}>
           {saveInProgress ? <CircularProgress size={21} /> : 'Save'}
         </Button>
       </DialogActions>
     </Dialog>
   )
 }
+export {EditPlanter}
 
-export default (EditPlanter)
+export default connect(
+  (state) => ({
+    plantersState: state.planters,
+  }),
+  (dispatch) => ({
+    plantersDispatch: dispatch.planters,
+  }),
+)(EditPlanter)

--- a/client/src/components/EditPlanter.js
+++ b/client/src/components/EditPlanter.js
@@ -10,9 +10,11 @@ import {
   Grid,
   TextField,
   CircularProgress,
+  MenuItem,
 } from '@material-ui/core'
 import api from '../api/planters'
 import ImageScroller from './ImageScroller'
+import { getOrganization } from '../api/apiUtils';
 
 const useStyle = makeStyles(theme => ({
   container: {
@@ -34,6 +36,10 @@ const EditPlanter = (props) => {
   const [planterUpdate, setPlanterUpdate] = useState(null)
   const [loadingPlanterImages, setLoadingPlanterImages] = useState(false)
   const [saveInProgress, setSaveInProgress] = useState(false)
+
+  useEffect(() => {
+    props.organizationDispatch.loadOrganizations()
+  }, [props.organizationDispatch])
 
   useEffect(() => {
     async function loadPlanterImages() {
@@ -149,6 +155,23 @@ const EditPlanter = (props) => {
               ))}
             </Grid>
           ))}
+          <Grid item container>
+            {!getOrganization() && <TextField
+                select
+                className={classes.textInput}
+                label='Organization'
+                value={getValue('organizationId')}
+                onChange={(e) => {handleChange('organizationId', e.target.value)}}
+                >
+                {[
+                  ...props.organizationState.organizationList
+                ].map((org) => (
+                  <MenuItem key={org.id} value={org.id}>
+                    {org.name}
+                  </MenuItem>
+                ))}
+              </TextField>}
+          </Grid>
         </Grid>
       </DialogContent>
       <DialogActions>
@@ -168,8 +191,10 @@ export {EditPlanter}
 export default connect(
   (state) => ({
     plantersState: state.planters,
+    organizationState: state.organizations,
   }),
   (dispatch) => ({
     plantersDispatch: dispatch.planters,
+    organizationDispatch: dispatch.organizations,
   }),
 )(EditPlanter)

--- a/client/src/components/EditPlanter.js
+++ b/client/src/components/EditPlanter.js
@@ -1,0 +1,193 @@
+import React, {useState, useEffect} from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import {
+  Button,
+  Card,
+  CardMedia,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Fab,
+  Grid,
+  TextField,
+  CircularProgress,
+} from '@material-ui/core'
+import {
+  CheckCircle,
+  ChevronLeft,
+  ChevronRight,
+} from '@material-ui/icons'
+import api from '../api/planters'
+
+const IMAGE_CARD_SIZE = 200
+const NUM_IMAGE_CARDS = 3
+
+const useStyle = makeStyles(theme => ({
+  imageScroller: {
+    width: `${IMAGE_CARD_SIZE * NUM_IMAGE_CARDS}px`,
+    height: `${IMAGE_CARD_SIZE}px`,
+    display: 'flex',
+    flexDirection: 'column',
+    flexWrap: 'wrap',
+    overflowX: 'auto',
+    marginBottom: theme.spacing(4),
+    justifyContent: 'center',
+  },
+  planterImageCard: {
+    width: `calc(${IMAGE_CARD_SIZE}px - ${theme.spacing(4)}px)`,
+    height: '100%',
+    margin: theme.spacing(2),
+    cursor: 'pointer',
+    position: 'relative',
+  },
+  planterImage: {
+    width: '100%',
+    height: '100%',
+  },
+  imageCheck: {
+    position: 'absolute',
+    top: theme.spacing(2),
+    left: theme.spacing(2),
+  },
+  scrollLeft: {
+    position: 'absolute',
+    left: 0,
+  },
+  scrollRight: {
+    position: 'absolute',
+    right: 0,
+  },
+  textInput: {
+    margin: theme.spacing()
+  },
+}));
+
+const MAX_IMAGES_INCREMENT = 20
+
+function EditPlanter(props) {
+  
+  const classes = useStyle()
+  const { isOpen, planter, onClose } = props
+
+  const [planterImages, setPlanterImages] = useState([])
+  const [planterUpdate, setPlanterUpdate] = useState(null)
+  const [saveInProgress, setSaveInProgress] = useState(false)
+  const [maxImages, setMaxImages] = useState(MAX_IMAGES_INCREMENT)
+
+  useEffect(() => {
+    async function loadPlanterImages() {
+      if (planter?.id) {
+        const selfies = await api.getPlanterSelfies(planter.id)
+
+        // TODO: Remove duplicates
+        setPlanterImages([
+          ...(planter?.imageUrl ? [planter.imageUrl] : []),
+          ...selfies.filter(img => img !== planter.imageUrl),
+        ])
+      }
+    }
+
+    setPlanterUpdate(null)
+    setMaxImages(MAX_IMAGES_INCREMENT)
+    loadPlanterImages()
+  }, [planter])
+
+  async function handleSave() {
+    if (planterUpdate) {
+      setSaveInProgress(true)
+      // TODO handle errors
+      await api.updatePlanter(planter.id, planterUpdate)
+      setSaveInProgress(false)
+    }
+    onClose()
+  }
+
+  function handleCancel() {
+    onClose()
+  }
+
+  function handleChange(key, val) {
+    let newPlanter = {...planterUpdate}
+    newPlanter[key] = val
+    setPlanterUpdate(newPlanter)
+  }
+
+  function loadMoreImages() {
+    setMaxImages(maxImages + MAX_IMAGES_INCREMENT)
+  }
+
+  function setPlanterImage(img) {
+    setPlanterUpdate({
+      ...planterUpdate,
+      imageUrl: img,
+    })
+  }
+
+  return(
+    <Dialog open={isOpen} aria-labelledby="form-dialog-title" maxWidth={false}>
+      <DialogTitle id="form-dialog-title">Edit Planter</DialogTitle>
+      <DialogContent>
+        <Grid container direction="column">
+          <Grid item className={classes.imageScroller}>
+            {planterImages.slice(0,maxImages).map((img, idx) =>
+              <Card key={`${idx}_${img}`} className={classes.planterImageCard} onClick={(e) => setPlanterImage(img)}>
+                <CardMedia image={img} title={img} className={classes.planterImage}/>
+                {(img === planterUpdate?.imageUrl || (!planterUpdate?.imageUrl && img === planter.imageUrl)) &&
+                  <CheckCircle color="primary" className={classes.imageCheck} />
+                }
+              </Card>
+            )}
+            {maxImages < planterImages.length && <Button onClick={loadMoreImages}>Load more</Button>}
+          </Grid>
+          {/* <Fab className={classes.scrollLeft}>
+            <ChevronLeft />
+          </Fab>
+          <Fab className={classes.scrollRight}>
+            <ChevronRight />
+          </Fab> */}
+          <Grid item container direction="row">
+            <Grid item>
+              <TextField
+                className={classes.textInput}
+                id="firstName"
+                label="First Name"
+                type="text"
+                variant="outlined"
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                onChange={(e) => {handleChange('firstName', e.target.value)}}
+                value={planterUpdate?.firstName || planter.firstName}
+              />
+            </Grid>
+            <Grid item>
+              <TextField
+                className={classes.textInput}
+                id="lastName"
+                label="Last Name"
+                type="text"
+                variant="outlined"
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                onChange={(e) => {handleChange('lastName', e.target.value)}}
+                value={planterUpdate?.lastName || planter.lastName}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave} variant="contained" color="primary" disabled={!planterUpdate || saveInProgress}>
+          {saveInProgress ? <CircularProgress size={21} /> : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default (EditPlanter)

--- a/client/src/components/EditPlanter.js
+++ b/client/src/components/EditPlanter.js
@@ -8,15 +8,15 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Fab,
+  // Fab,
   Grid,
   TextField,
   CircularProgress,
 } from '@material-ui/core'
 import {
   CheckCircle,
-  ChevronLeft,
-  ChevronRight,
+  // ChevronLeft,
+  // ChevronRight,
 } from '@material-ui/icons'
 import api from '../api/planters'
 
@@ -72,17 +72,19 @@ function EditPlanter(props) {
 
   const [planterImages, setPlanterImages] = useState([])
   const [planterUpdate, setPlanterUpdate] = useState(null)
+  const [loadingPlanterImages, setLoadingPlanterImages] = useState(false)
   const [saveInProgress, setSaveInProgress] = useState(false)
   const [maxImages, setMaxImages] = useState(MAX_IMAGES_INCREMENT)
 
   useEffect(() => {
     async function loadPlanterImages() {
       if (planter?.id) {
+        setLoadingPlanterImages(true)
         const selfies = await api.getPlanterSelfies(planter.id)
+        setLoadingPlanterImages(false)
 
-        // TODO: Remove duplicates
         setPlanterImages([
-          ...(planter?.imageUrl ? [planter.imageUrl] : []),
+          ...(planter.imageUrl ? [planter.imageUrl] : []),
           ...selfies.filter(img => img !== planter.imageUrl),
         ])
       }
@@ -124,20 +126,25 @@ function EditPlanter(props) {
     })
   }
 
+  // TODO separate image scroller into a function component
   return(
     <Dialog open={isOpen} aria-labelledby="form-dialog-title" maxWidth={false}>
       <DialogTitle id="form-dialog-title">Edit Planter</DialogTitle>
       <DialogContent>
         <Grid container direction="column">
           <Grid item className={classes.imageScroller}>
-            {planterImages.slice(0,maxImages).map((img, idx) =>
-              <Card key={`${idx}_${img}`} className={classes.planterImageCard} onClick={(e) => setPlanterImage(img)}>
-                <CardMedia image={img} title={img} className={classes.planterImage}/>
-                {(img === planterUpdate?.imageUrl || (!planterUpdate?.imageUrl && img === planter.imageUrl)) &&
-                  <CheckCircle color="primary" className={classes.imageCheck} />
-                }
-              </Card>
-            )}
+            {loadingPlanterImages ? <CircularProgress/> :
+              (planterImages.length ? 
+                planterImages.slice(0, maxImages).map((img, idx) =>
+                  <Card key={`${idx}_${img}`} className={classes.planterImageCard} onClick={() => setPlanterImage(img)}>
+                    <CardMedia image={img} title={img} className={classes.planterImage}/>
+                    {(img === planterUpdate?.imageUrl || (!planterUpdate?.imageUrl && img === planter.imageUrl)) &&
+                      <CheckCircle color="primary" className={classes.imageCheck} />
+                    }
+                  </Card>
+                )
+              : 'No planter images available')
+            }
             {maxImages < planterImages.length && <Button onClick={loadMoreImages}>Load more</Button>}
           </Grid>
           {/* <Fab className={classes.scrollLeft}>

--- a/client/src/components/EditPlanter.js
+++ b/client/src/components/EditPlanter.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { connect } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
 import {
@@ -9,58 +9,73 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  // Fab,
+  Fab,
   Grid,
   TextField,
   CircularProgress,
 } from '@material-ui/core'
 import {
-  CheckCircle,
-  // ChevronLeft,
-  // ChevronRight,
+  ChevronLeft,
+  ChevronRight,
 } from '@material-ui/icons'
 import api from '../api/planters'
 
-const IMAGE_CARD_SIZE = 200
+const IMAGE_CARD_SIZE = 150
 const NUM_IMAGE_CARDS = 3
+const SCROLL_BUTTON_SIZE = 48
 
 const useStyle = makeStyles(theme => ({
+  container: {
+    position: 'relative',
+    padding: theme.spacing(0, 4),
+  },
   imageScroller: {
     width: `${IMAGE_CARD_SIZE * NUM_IMAGE_CARDS}px`,
-    height: `${IMAGE_CARD_SIZE}px`,
+    height: `${IMAGE_CARD_SIZE + 16}px`,
     display: 'flex',
     flexDirection: 'column',
     flexWrap: 'wrap',
     overflowX: 'auto',
     marginBottom: theme.spacing(4),
     justifyContent: 'center',
+    alignItems: 'center',
+    textAlign: 'center',
   },
   planterImageCard: {
-    width: `calc(${IMAGE_CARD_SIZE}px - ${theme.spacing(4)}px)`,
     height: '100%',
-    margin: theme.spacing(2),
+    margin: theme.spacing(1.5),
+    width: `${IMAGE_CARD_SIZE - theme.spacing(3)}px`,
     cursor: 'pointer',
     position: 'relative',
+    transition: 'box-shadow 0.1s ease-in-out',
   },
   planterImage: {
     width: '100%',
     height: '100%',
+    transition: 'box-shadow 0.1s ease-in-out',
+  },
+  selectedImage: {
+    boxShadow: `inset 0 0 0 ${theme.spacing()}px ${theme.palette.primary.main}`,
   },
   imageCheck: {
     position: 'absolute',
     top: theme.spacing(2),
     left: theme.spacing(2),
   },
-  scrollLeft: {
+  scrollButton: {
+    height: `${SCROLL_BUTTON_SIZE}px`,
+    width: `${SCROLL_BUTTON_SIZE}px`,
     position: 'absolute',
-    left: 0,
+    top: `${IMAGE_CARD_SIZE/2 - SCROLL_BUTTON_SIZE/2}px`
+  },
+  scrollLeft: {
+    left: `-${SCROLL_BUTTON_SIZE/4}px`,
   },
   scrollRight: {
-    position: 'absolute',
-    right: 0,
+    right: `-${SCROLL_BUTTON_SIZE/4}px`,
   },
   textInput: {
-    margin: theme.spacing(),
+    margin: theme.spacing(2,1),
     flexGrow: 1,
   },
 }));
@@ -71,6 +86,7 @@ const EditPlanter = (props) => {
   
   const classes = useStyle()
   const { isOpen, planter, onClose } = props
+  const imageScrollerRef = useRef(null);
 
   const [planterImages, setPlanterImages] = useState([])
   const [planterUpdate, setPlanterUpdate] = useState(null)
@@ -128,59 +144,108 @@ const EditPlanter = (props) => {
     })
   }
 
+  function getValue(attr) {
+    // Ensure empty strings are not overlooked
+    if (planterUpdate?.[attr] != null) {
+      return planterUpdate[attr]
+    } else if (planter[attr] != null) {
+      return planter[attr]
+    }
+    return ''
+  }
+
+  function scrollImagesLeft() {
+    scrollImages(-NUM_IMAGE_CARDS)
+  }
+
+  function scrollImagesRight() {
+    scrollImages(NUM_IMAGE_CARDS)
+  }
+
+  function scrollImages(numImages) {
+    const startPos = Math.round(imageScrollerRef.current.scrollLeft/IMAGE_CARD_SIZE) * IMAGE_CARD_SIZE
+    imageScrollerRef.current.scrollTo({
+      top: 0,
+      left: startPos + numImages*IMAGE_CARD_SIZE,
+      behavior: 'smooth'
+    })
+  }
+
+  function isImageSelected(img) {
+    return img === planterUpdate?.imageUrl || (!planterUpdate?.imageUrl && img === planter.imageUrl)
+  }
+
+  const inputs = [[
+    {
+      attr: 'firstName',
+      label: 'First Name',
+    },{
+      attr: 'lastName',
+      label: 'Last Name',
+    },
+  ],[
+    {
+      attr: 'email',
+      label: 'Email Address',
+      type: 'email'
+    },
+  ],[
+    {
+      attr: 'phone',
+      label: 'Phone Number',
+      type: 'tel'
+    },
+  ]]
+
   // TODO separate image scroller into a function component
   return(
     <Dialog open={isOpen} aria-labelledby="form-dialog-title" maxWidth={false}>
       <DialogTitle id="form-dialog-title">Edit Planter</DialogTitle>
       <DialogContent>
-        <Grid container direction="column">
-          <Grid item className={classes.imageScroller}>
+        <Grid container direction="column" className={classes.container}>
+          <Grid item className={classes.imageScroller} ref={imageScrollerRef}>
             {loadingPlanterImages ? <CircularProgress/> :
               (planterImages.length ? 
                 planterImages.slice(0, maxImages).map((img, idx) =>
-                  <Card key={`${idx}_${img}`} className={classes.planterImageCard} onClick={() => setPlanterImage(img)}>
-                    <CardMedia image={img} title={img} className={classes.planterImage}/>
-                    {(img === planterUpdate?.imageUrl || (!planterUpdate?.imageUrl && img === planter.imageUrl)) &&
-                      <CheckCircle color="primary" className={classes.imageCheck} />
-                    }
+                  <Card key={`${idx}_${img}`} className={classes.planterImageCard}
+                        onClick={() => setPlanterImage(img)} raised={isImageSelected(img)}>
+                    <CardMedia image={img} title={img}
+                               className={`${classes.planterImage} ${isImageSelected(img) && classes.selectedImage}`}/>
                   </Card>
                 )
               : 'No planter images available')
             }
             {maxImages < planterImages.length && <Button onClick={loadMoreImages}>Load more</Button>}
           </Grid>
-          {/* <Fab className={classes.scrollLeft}>
-            <ChevronLeft />
-          </Fab>
-          <Fab className={classes.scrollRight}>
-            <ChevronRight />
-          </Fab> */}
-          <Grid item container direction="row">
-              <TextField
-                className={classes.textInput}
-                id="firstName"
-                label="First Name"
-                type="text"
-                variant="outlined"
-                InputLabelProps={{
-                  shrink: true,
-                }}
-                onChange={(e) => {handleChange('firstName', e.target.value)}}
-                value={planterUpdate?.firstName || planter.firstName}
-              />
-              <TextField
-                className={classes.textInput}
-                id="lastName"
-                label="Last Name"
-                type="text"
-                variant="outlined"
-                InputLabelProps={{
-                  shrink: true,
-                }}
-                onChange={(e) => {handleChange('lastName', e.target.value)}}
-                value={planterUpdate?.lastName || planter.lastName}
-              />
-          </Grid>
+          {planterImages.length > NUM_IMAGE_CARDS &&
+            <React.Fragment>
+              <Fab className={`${classes.scrollButton} ${classes.scrollLeft}`} onClick={scrollImagesLeft}>
+                <ChevronLeft />
+              </Fab>
+              <Fab className={`${classes.scrollButton} ${classes.scrollRight}`} onClick={scrollImagesRight}>
+                <ChevronRight />
+              </Fab>
+            </React.Fragment>
+          }
+          {inputs.map((row, rowIdx) => (
+            <Grid item container direction="row" key={rowIdx}>
+              {row.map((input, colIdx) => (
+                <TextField
+                  key={`${rowIdx}_${colIdx}`}
+                  className={classes.textInput}
+                  id={input.attr}
+                  label={input.label}
+                  type={input.type || 'text'}
+                  variant="outlined"
+                  InputLabelProps={{
+                    shrink: true,
+                  }}
+                  onChange={(e) => {handleChange(input.attr, e.target.value)}}
+                  value={getValue(input.attr)}
+                />
+              ))}
+            </Grid>
+          ))}
         </Grid>
       </DialogContent>
       <DialogActions>

--- a/client/src/components/EditPlanter.js
+++ b/client/src/components/EditPlanter.js
@@ -47,20 +47,14 @@ const useStyle = makeStyles(theme => ({
     width: `${IMAGE_CARD_SIZE - theme.spacing(3)}px`,
     cursor: 'pointer',
     position: 'relative',
-    transition: 'box-shadow 0.1s ease-in-out',
   },
   planterImage: {
     width: '100%',
     height: '100%',
-    transition: 'box-shadow 0.1s ease-in-out',
   },
-  selectedImage: {
-    boxShadow: `inset 0 0 0 ${theme.spacing()}px ${theme.palette.primary.main}`,
-  },
-  imageCheck: {
-    position: 'absolute',
-    top: theme.spacing(2),
-    left: theme.spacing(2),
+  selectedImageCard: {
+    border: `solid ${theme.spacing(1.5)}px ${theme.palette.primary.main}`,
+    margin: 0,
   },
   scrollButton: {
     height: `${SCROLL_BUTTON_SIZE}px`,
@@ -130,7 +124,16 @@ const EditPlanter = (props) => {
   function handleChange(key, val) {
     let newPlanter = {...planterUpdate}
     newPlanter[key] = val
-    setPlanterUpdate(newPlanter)
+
+    const changed = Object.keys(newPlanter).some((key) => {
+      return newPlanter[key] !== planter[key];
+    })
+
+    if (changed) {
+      setPlanterUpdate(newPlanter)
+    } else {
+      setPlanterUpdate(null)
+    }
   }
 
   function loadMoreImages() {
@@ -207,10 +210,10 @@ const EditPlanter = (props) => {
             {loadingPlanterImages ? <CircularProgress/> :
               (planterImages.length ? 
                 planterImages.slice(0, maxImages).map((img, idx) =>
-                  <Card key={`${idx}_${img}`} className={classes.planterImageCard}
-                        onClick={() => setPlanterImage(img)} raised={isImageSelected(img)}>
+                  <Card key={`${idx}_${img}`} onClick={() => setPlanterImage(img)}
+                        className={`${classes.planterImageCard} ${isImageSelected(img) && classes.selectedImageCard}`}>
                     <CardMedia image={img} title={img}
-                               className={`${classes.planterImage} ${isImageSelected(img) && classes.selectedImage}`}/>
+                               className={classes.planterImage}/>
                   </Card>
                 )
               : 'No planter images available')
@@ -252,7 +255,7 @@ const EditPlanter = (props) => {
         <Button onClick={handleCancel}>
           Cancel
         </Button>
-        <Button onClick={handleSave} variant="contained" color="primary"
+        <Button id="save" onClick={handleSave} variant="contained" color="primary"
                 disabled={!planterUpdate || saveInProgress}>
           {saveInProgress ? <CircularProgress size={21} /> : 'Save'}
         </Button>

--- a/client/src/components/EditPlanter.spec.py.js
+++ b/client/src/components/EditPlanter.spec.py.js
@@ -41,17 +41,24 @@ describe('EditPlanter', () => {
 
     const planter = {
       id: 12345,
-      imageUrl: 'https://greenstand.org/fileadmin/_processed_/f/e/csm_MVIMG_20200303_103438_e3a293cbe2.jpg',
+      imageUrl: 'https://greenstand.org/fileadmin/_processed_/f/e/csm_MVIMG_20200303_103438_be16bc7f80.jpg',
       firstName: 'Teston',
       lastName: 'Blumenfail',
       email: 'test@email.com',
       phone: '+1234567890'
     }
 
+    let planterSelfies
+
     beforeEach(() =>{
-      cy.stub(api, 'getPlanterSelfies').returns([
-        'https://greenstand.org/fileadmin/_processed_/9/f/csm_2019.08.12.09.54.39_1ca43554-b139-4ae2-bbc9-c9a37c43e645_IMG_20190812_093641_-1471408775_56b4574917.jpg'
-      ])
+      planterSelfies = [
+        'https://greenstand.org/fileadmin/_processed_/d/4/csm_little_Jony_bdf756638d.jpg',
+        'https://greenstand.org/fileadmin/_processed_/9/f/csm_2019.08.12.09.54.39_1ca43554-b139-4ae2-bbc9-c9a37c43e645_IMG_20190812_093641_-1471408775_0bb24d7c21.jpg',
+        'https://greenstand.org/fileadmin/_processed_/e/3/csm_IMG_0017_3c859de144.jpg',
+        'https://greenstand.org/fileadmin/_processed_/9/3/csm_PHOTO-2019-08-05-11-50-37_f0d0281499.jpg',
+      ]
+
+      cy.stub(api, 'getPlanterSelfies').returns(planterSelfies)
       mount(
         <Provider store={store}>
           <ThemeProvider theme={theme}>
@@ -62,11 +69,17 @@ describe('EditPlanter', () => {
     })
 
     it('should display planter details', () => {
-      cy.get('input#firstName').should('have.value', planter.firstName)
+      cy.get(`[title="${planter.imageUrl}"]`).should('have.css', 'background-image', `url("${planter.imageUrl}")`)
       cy.get('input#firstName').should('have.value', planter.firstName)
       cy.get('input#lastName').should('have.value', planter.lastName)
       cy.get('input#email').should('have.value', planter.email)
       cy.get('input#phone').should('have.value', planter.phone)
+    })
+
+    it('should display all other planter images', () => {
+      planterSelfies.forEach((img) => {
+        cy.get(`[title="${img}"]`).should('have.css', 'background-image', `url("${img}")`)
+      })
     })
 
     it('should enable Save button when values change', () => {

--- a/client/src/components/EditPlanter.spec.py.js
+++ b/client/src/components/EditPlanter.spec.py.js
@@ -19,7 +19,7 @@ describe('EditPlanter', () => {
         planters: {
           state: {},
           effects: {
-            updatePlanter(payload, state) { }
+            updatePlanter(_payload, _state) { }
           }
         }
       }

--- a/client/src/components/EditPlanter.spec.py.js
+++ b/client/src/components/EditPlanter.spec.py.js
@@ -1,0 +1,87 @@
+/* eslint-disable */
+import { mount } from 'cypress-react-unit-test'
+import React from 'react'
+import { Provider } from 'react-redux'
+import theme from './common/theme'
+import { ThemeProvider } from '@material-ui/core/styles'
+import { init } from '@rematch/core'
+import api from '../api/planters'
+
+import EditPlanter from './EditPlanter'
+
+describe('EditPlanter', () => {
+
+  let store
+
+  beforeEach(() => {
+    store = init({
+      models: {
+        planters: {
+          state: {},
+          effects: {
+            updatePlanter(payload, state) { }
+          }
+        }
+      }
+    })
+  })
+
+  it('works', () => {
+    mount(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <EditPlanter planter={{}} isOpen={true} onClose={() => {}} />
+        </ThemeProvider>
+      </Provider>
+    )
+    cy.contains(/Edit Planter/i)
+  })
+
+  describe('with valid planter', () => {
+
+    const planter = {
+      id: 12345,
+      imageUrl: 'https://greenstand.org/fileadmin/_processed_/f/e/csm_MVIMG_20200303_103438_e3a293cbe2.jpg',
+      firstName: 'Teston',
+      lastName: 'Blumenfail',
+      email: 'test@email.com',
+      phone: '+1234567890'
+    }
+
+    beforeEach(() =>{
+      cy.stub(api, 'getPlanterSelfies').returns([
+        'https://greenstand.org/fileadmin/_processed_/9/f/csm_2019.08.12.09.54.39_1ca43554-b139-4ae2-bbc9-c9a37c43e645_IMG_20190812_093641_-1471408775_56b4574917.jpg'
+      ])
+      mount(
+        <Provider store={store}>
+          <ThemeProvider theme={theme}>
+            <EditPlanter planter={planter} isOpen={true} onClose={() => {}} />
+          </ThemeProvider>
+        </Provider>
+      )
+    })
+
+    it('should display planter details', () => {
+      cy.get('input#firstName').should('have.value', planter.firstName)
+      cy.get('input#firstName').should('have.value', planter.firstName)
+      cy.get('input#lastName').should('have.value', planter.lastName)
+      cy.get('input#email').should('have.value', planter.email)
+      cy.get('input#phone').should('have.value', planter.phone)
+    })
+
+    it('should enable Save button when values change', () => {
+      cy.get('button#save').should('be.disabled')
+      cy.get('input#firstName').type('abc')
+      cy.get('button#save').should('be.enabled')
+    })
+
+    it('should update the planter when Save is clicked', () => {
+      cy.spy(store.dispatch.planters, 'updatePlanter')
+      cy.get('input#firstName').type('abc')
+      cy.get('button#save').then(($button) => {
+        $button[0].click()
+        expect(store.dispatch.planters.updatePlanter).to.be.called
+      })
+    })
+  })
+})

--- a/client/src/components/ImageScroller.js
+++ b/client/src/components/ImageScroller.js
@@ -1,0 +1,149 @@
+import React, { useState, useRef } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import {
+  Fab,
+  Grid,
+  CircularProgress,
+  Card,
+  CardMedia,
+  Button,
+} from '@material-ui/core'
+import {
+  ChevronLeft,
+  ChevronRight,
+} from '@material-ui/icons'
+
+/* This component currently uses fixed size cards and scroll window,
+ * but it wouldn't be too difficult to make it more flexible.
+ */
+const MAX_IMAGES_INCREMENT = 20
+const IMAGE_CARD_SIZE = 150
+const NUM_IMAGE_CARDS = 3
+const SCROLL_BUTTON_SIZE = 48
+
+const useStyle = makeStyles(theme => ({
+  container: {
+    position: 'relative',
+    width: `${IMAGE_CARD_SIZE * NUM_IMAGE_CARDS}px`,
+  },
+  imageList: {
+    height: `${IMAGE_CARD_SIZE + 16}px`,
+    display: 'flex',
+    flexDirection: 'column',
+    flexWrap: 'wrap',
+    overflowX: 'auto',
+    marginBottom: theme.spacing(4),
+    justifyContent: 'start',
+    alignItems: 'center',
+    textAlign: 'center',
+  },
+  imageCard: {
+    height: '100%',
+    margin: theme.spacing(1.5),
+    width: `${IMAGE_CARD_SIZE - theme.spacing(3)}px`,
+    cursor: 'pointer',
+    position: 'relative',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  selectedImageCard: {
+    border: `solid ${theme.spacing(1.5)}px ${theme.palette.primary.main}`,
+    margin: 0,
+  },
+  scrollButton: {
+    height: `${SCROLL_BUTTON_SIZE}px`,
+    width: `${SCROLL_BUTTON_SIZE}px`,
+    position: 'absolute',
+    top: `${IMAGE_CARD_SIZE/2 - SCROLL_BUTTON_SIZE/2}px`
+  },
+  scrollLeft: {
+    left: `-${SCROLL_BUTTON_SIZE/2}px`,
+  },
+  scrollRight: {
+    right: `-${SCROLL_BUTTON_SIZE/2}px`,
+  },
+  loadMore: {
+    margin: theme.spacing(1.5),
+  },
+  placeholder: {
+    display: 'flex',
+    justifyContent: 'start',
+    alignItems: 'center',
+    textAlign: 'center',
+    height: '100%',
+  },
+}));
+
+export default function ImageScroller(props) {
+  
+  const {
+    images,
+    selectedImage,
+    onSelectImage,
+    loading = false,
+    blankMessage = ''
+  } = props;
+
+  const classes = useStyle()
+  const [ maxImages, setMaxImages ] = useState(MAX_IMAGES_INCREMENT)
+  const imageScrollerRef = useRef(null);
+
+  function loadMoreImages() {
+    setMaxImages(maxImages + MAX_IMAGES_INCREMENT)
+  }
+
+  function scrollImagesLeft() {
+    scrollImages(-NUM_IMAGE_CARDS)
+  }
+
+  function scrollImagesRight() {
+    scrollImages(NUM_IMAGE_CARDS)
+  }
+
+  function scrollImages(numImages) {
+    const startPos = Math.round(imageScrollerRef.current.scrollLeft/IMAGE_CARD_SIZE) * IMAGE_CARD_SIZE
+    imageScrollerRef.current.scrollTo({
+      top: 0,
+      left: startPos + numImages*IMAGE_CARD_SIZE,
+      behavior: 'smooth'
+    })
+  }
+
+  return (
+    <div className={classes.container}>
+      <Grid item className={`image-list ${classes.imageList}`} ref={imageScrollerRef}>
+      {loading ? <div className={classes.placeholder}><CircularProgress id="loading"/></div> :
+        (images.length ? 
+          images.slice(0, maxImages).map((img, idx) =>
+            <Card key={`${idx}_${img}`} onClick={() => onSelectImage(img)}
+                  className={`image-card ${classes.imageCard} ${img === selectedImage && classes.selectedImageCard}`}>
+              <CardMedia image={img} title={img} className={classes.image}/>
+            </Card>
+          )
+        : <div className={classes.placeholder}>{blankMessage}</div>)
+      }
+      {maxImages < images.length &&
+        <Button id="load-more" className={classes.loadMore} onClick={loadMoreImages}>
+          Load more
+        </Button>
+      }
+      </Grid>
+      {images.length > NUM_IMAGE_CARDS &&
+        <React.Fragment>
+          <Fab id="scroll-left"
+            className={`${classes.scrollButton} ${classes.scrollLeft}`}
+            onClick={scrollImagesLeft}>
+            <ChevronLeft />
+          </Fab>
+          <Fab id="scroll-right"
+            className={`${classes.scrollButton} ${classes.scrollRight}`}
+            onClick={scrollImagesRight}>
+            <ChevronRight />
+          </Fab>
+        </React.Fragment>
+      }
+    </div>
+  );
+}

--- a/client/src/components/ImageScroller.spec.py.js
+++ b/client/src/components/ImageScroller.spec.py.js
@@ -1,0 +1,107 @@
+/* eslint-disable */
+import { mount } from 'cypress-react-unit-test'
+import React from 'react'
+import theme from './common/theme'
+import { ThemeProvider } from '@material-ui/core/styles'
+
+import ImageScroller from './ImageScroller'
+
+describe('ImageScroller', () => {
+
+  it('works', () => {
+    const blankMessage = 'No images'
+    mount(
+      <ThemeProvider theme={theme}>
+        <ImageScroller images={[]} selectedImage={null} onSelectImage={() => {}} blankMessage={blankMessage} />
+      </ThemeProvider>
+    )
+    cy.contains(blankMessage)
+    cy.get('.image-list').should('exist')
+    cy.get('.image-card').should('not.exist')
+    cy.get('#scroll-right').should('not.exist')
+    cy.get('#scroll-right').should('not.exist')
+    cy.get('#loading').should('not.exist')
+  })
+
+  it('should show loading indicator', () => {
+    mount(
+      <ThemeProvider theme={theme}>
+        <ImageScroller
+          images={[]}
+          selectedImage={null}
+          onSelectImage={() => {}}
+          loading={true}
+        />
+      </ThemeProvider>
+    )
+
+    cy.get('#loading').should('exist')
+  })
+  
+  describe('with images', () => {
+
+    let images
+    let selectedImage
+
+    const selectImage = (img) => {
+      selectedImage = img
+    }
+
+    beforeEach(() =>{
+      images = [
+        'https://greenstand.org/fileadmin/_processed_/d/4/csm_little_Jony_bdf756638d.jpg',
+        'https://greenstand.org/fileadmin/_processed_/9/f/csm_2019.08.12.09.54.39_1ca43554-b139-4ae2-bbc9-c9a37c43e645_IMG_20190812_093641_-1471408775_0bb24d7c21.jpg',
+        'https://greenstand.org/fileadmin/_processed_/e/3/csm_IMG_0017_3c859de144.jpg',
+        'https://greenstand.org/fileadmin/_processed_/9/3/csm_PHOTO-2019-08-05-11-50-37_f0d0281499.jpg',
+      ]
+
+      mount(
+        <ThemeProvider theme={theme}>
+          <ImageScroller
+            images={images}
+            selectedImage={selectedImage}
+            onSelectImage={selectImage}/>
+        </ThemeProvider>
+      )
+    })
+
+    it('should display all images', () => {
+      images.forEach((img) => {
+        cy.get(`[title="${img}"]`).should('have.css', 'background-image', `url("${img}")`)
+      })
+    })
+
+    it('should select an image', () => {
+      cy.get('.image-card').first().click().then(() => {
+        expect(selectedImage).to.equal(images[0])
+      })
+    })
+  })
+
+  describe('with many images', () => {
+    const images = [...new Array(100)].map((_val, idx) => idx.toString())
+
+    beforeEach(() => {
+      mount(
+        <ThemeProvider theme={theme}>
+          <ImageScroller
+            images={images}
+            selectedImage={null}
+            onSelectImage={() => {}}
+          />
+        </ThemeProvider>
+      )
+    })
+
+    it('should display "load more" button', () => {
+      cy.contains(/load more/i)
+    })
+
+    it('should load more images', () => {
+      cy.get('.image-card').should('have.length', 20)
+      cy.get('#load-more').click().then(() => {
+        cy.get('.image-card').should('have.length', 40)
+      })
+    })
+  })
+})

--- a/client/src/components/PlanterDetail.js
+++ b/client/src/components/PlanterDetail.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import CardMedia from '@material-ui/core/CardMedia'
@@ -53,25 +54,40 @@ const useStyle = makeStyles(theme => ({
   }
 }));
 
-function PlanterDetail(props){
+const PlanterDetail = (props) => {
   
   const [planterRegistration, setPlanterRegistration] = React.useState(null)
   const [editDialogOpen, setEditDialogOpen] = React.useState(false)
-  const classes = useStyle();
-  const {planter} = props;
+  const [planter, setPlanter] = React.useState({})
+  const classes = useStyle()
+  const { planterId } = props
   const { user } = React.useContext(AppContext)
 
   React.useEffect(() => {
-    if (planter && planter.id && (!planterRegistration || planterRegistration.planterId !== planter.id)) {
-      setPlanterRegistration(null)
-      api.getPlanterRegistrations(planter.id).then(registrations => {
-        if (registrations && registrations.length) {
-          setPlanterRegistration(registrations[0])
-        }
-      })
-    }
-  }, [planter, planterRegistration])
+    async function loadPlanterDetail() {
+      if (planter && planter.id !== planterId) {
+        setPlanter({})
+      }
 
+      if (planterId) {
+        const match = await props.plantersDispatch.getPlanter({id: planterId})
+        setPlanter(match)
+
+        if (!planterRegistration || planterRegistration.planterId !== planterId) {
+          setPlanterRegistration(null)
+          api.getPlanterRegistrations(planterId).then(registrations => {
+            if (registrations && registrations.length) {
+              setPlanterRegistration(registrations[0])
+            }
+          })
+        }
+      }
+    }
+
+    loadPlanterDetail()
+  // eslint-disable-next-line
+  }, [planterId, planterRegistration, props.plantersState.planters, props.plantersDispatch])
+    
   function handleEditClick() {
     setEditDialogOpen(true)
   }
@@ -165,5 +181,13 @@ function PlanterDetail(props){
     </React.Fragment>
   )
 }
+export { PlanterDetail }
 
-export default (PlanterDetail)
+export default connect(
+  (state) => ({
+    plantersState: state.planters,
+  }),
+  (dispatch) => ({
+    plantersDispatch: dispatch.planters,
+  }),
+)(PlanterDetail)

--- a/client/src/components/PlanterDetail.js
+++ b/client/src/components/PlanterDetail.js
@@ -176,7 +176,6 @@ const PlanterDetail = (props) => {
           </Grid>
         </Grid>
       </Drawer>
-      {/* TODO: Reload planter details on save */}
       <EditPlanter isOpen={editDialogOpen} planter={planter} onClose={handleEditClose}></EditPlanter>
     </React.Fragment>
   )

--- a/client/src/components/PlanterDetail.js
+++ b/client/src/components/PlanterDetail.js
@@ -44,8 +44,9 @@ const useStyle = makeStyles(theme => ({
   },
   editButton: {
     position: 'absolute',
-    bottom: '0',
-    right: '10%',
+    right: 0,
+    bottom: 0,
+    transform: 'translate(-50%, 50%)',
   },
   imageContainer: {
     position: 'relative',

--- a/client/src/components/PlanterDetail.js
+++ b/client/src/components/PlanterDetail.js
@@ -6,11 +6,16 @@ import Grid from '@material-ui/core/Grid'
 import IconButton from '@material-ui/core/IconButton'
 import Box from '@material-ui/core/Box'
 import Drawer from '@material-ui/core/Drawer'
-import Close from "@material-ui/icons/Close";
-import Person from "@material-ui/icons/Person";
-import Divider from "@material-ui/core/Divider";
+import Close from '@material-ui/icons/Close'
+import Person from '@material-ui/icons/Person'
+import Divider from '@material-ui/core/Divider'
+import EditIcon from '@material-ui/icons/Edit'
+import Fab from '@material-ui/core/Fab'
 import api from '../api/planters';
-import { getDateTimeStringLocale } from '../common/locale';
+import { getDateTimeStringLocale } from '../common/locale'
+import { hasPermission, POLICIES } from '../models/auth'
+import { AppContext } from './Context'
+import EditPlanter from './EditPlanter'
 
 const useStyle = makeStyles(theme => ({
   root: {
@@ -20,30 +25,40 @@ const useStyle = makeStyles(theme => ({
     padding: theme.spacing(4),
   },
   cardMedia: {
-    height: "378px",
+    height: '378px',
   },
   personBox: {
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    backgroundColor: "lightgray",
-    height: "100%",
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'lightgray',
+    height: '100%',
   },
   person: {
     height: 180,
     width: 180,
-    fill: "gray",
+    fill: 'gray',
   },
   name: {
-    textTransform: "capitalize",
+    textTransform: 'capitalize',
   },
+  editButton: {
+    position: 'absolute',
+    bottom: '0',
+    right: '10%',
+  },
+  imageContainer: {
+    position: 'relative',
+  }
 }));
 
 function PlanterDetail(props){
   
   const [planterRegistration, setPlanterRegistration] = React.useState(null)
+  const [editDialogOpen, setEditDialogOpen] = React.useState(false)
   const classes = useStyle();
   const {planter} = props;
+  const { user } = React.useContext(AppContext)
 
   React.useEffect(() => {
     if (planter && planter.id && (!planterRegistration || planterRegistration.planterId !== planter.id)) {
@@ -56,78 +71,97 @@ function PlanterDetail(props){
     }
   }, [planter, planterRegistration])
 
+  function handleEditClick() {
+    setEditDialogOpen(true)
+  }
+
+  function handleEditClose() {
+    setEditDialogOpen(false)
+  }
+
   return(
-    <Drawer anchor="right" open={props.open} onClose={props.onClose}>
-      <Grid className={classes.root} >
-        <Grid container direction="column">
-          <Grid item>
-            <Grid container justify="space-between" alignItems="center" >
-              <Grid item>
-                <Box m={4} >
-                  <Typography color="primary" variant="h6" >
-                    Planter Detail
-                  </Typography>
-                </Box>
-              </Grid>
-              <Grid item>
-                <IconButton onClick={() => props.onClose()}>
-                  <Close />
-                </IconButton>
+    <React.Fragment>
+      <Drawer anchor='right' open={props.open} onClose={props.onClose}>
+        <Grid className={classes.root} >
+          <Grid container direction='column'>
+            <Grid item>
+              <Grid container justify='space-between' alignItems='center' >
+                <Grid item>
+                  <Box m={4} >
+                    <Typography color='primary' variant='h6' >
+                      Planter Detail
+                    </Typography>
+                  </Box>
+                </Grid>
+                <Grid item>
+                  <IconButton onClick={() => props.onClose()}>
+                    <Close />
+                  </IconButton>
+                </Grid>
               </Grid>
             </Grid>
-          </Grid>
-          <Grid item>
-
-            {planter.imageUrl &&
-              <CardMedia className={classes.cardMedia} image={planter.imageUrl} />
-            }
-            {!planter.imageUrl &&
-              <CardMedia className={classes.cardMedia} >
-                <Grid container className={classes.personBox} >
-                  <Person className={classes.person} />
-                </Grid>
-              </CardMedia>
-            }
-          </Grid>
-          <Grid item className={classes.box} >
-            <Typography variant="h5" color="primary" className={classes.name} >{planter.firstName} {planter.lastName}</Typography>
-            <Typography variant="body2">ID:{planter.id}</Typography>
-          </Grid>
-          <Divider/>
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Email address</Typography>
-            <Typography variant="body1" >{planter.email || "---"}</Typography>
-          </Grid>
-          <Divider/>
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Phone number</Typography>
-            <Typography variant="body1" >{planter.phone || "---"}</Typography>
-          </Grid>
-          <Divider/>
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Person ID</Typography>
-            <Typography variant="body1" >{planter.personId || "---"}</Typography>
-          </Grid>
-          <Divider/>
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Organization</Typography>
-            <Typography variant="body1" >{planter.organization || "---" }</Typography>
-          </Grid>
-          <Divider />
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Organization ID</Typography>
-            <Typography variant="body1" >{planter.organizationId || "---"}</Typography>
-          </Grid>
-          <Divider />
-          <Grid container direction="column" className={classes.box}>
-            <Typography variant="subtitle1" >Registered</Typography>
-            <Typography variant="body1" >
-              {(planterRegistration && getDateTimeStringLocale(planterRegistration.createdAt)) || "---"}
-            </Typography>
+            <Grid item className={classes.imageContainer}>
+              {planter.imageUrl &&
+                <CardMedia className={classes.cardMedia} image={planter.imageUrl} />
+              }
+              {!planter.imageUrl &&
+                <CardMedia className={classes.cardMedia} >
+                  <Grid container className={classes.personBox} >
+                    <Person className={classes.person} />
+                  </Grid>
+                </CardMedia>
+              }
+              {hasPermission(user, [POLICIES.SUPER_PERMISSION, POLICIES.MANAGE_PLANTER]) &&
+                <Fab
+                  className={classes.editButton}
+                  onClick={() => handleEditClick()}
+                >
+                  <EditIcon />
+                </Fab>
+              }
+            </Grid>
+            <Grid item className={classes.box} >
+              <Typography variant='h5' color='primary' className={classes.name} >{planter.firstName} {planter.lastName}</Typography>
+              <Typography variant='body2'>ID:{planter.id}</Typography>
+            </Grid>
+            <Divider/>
+            <Grid container direction='column' className={classes.box}>
+              <Typography variant='subtitle1' >Email address</Typography>
+              <Typography variant='body1' >{planter.email || '---'}</Typography>
+            </Grid>
+            <Divider/>
+            <Grid container direction='column' className={classes.box}>
+              <Typography variant='subtitle1' >Phone number</Typography>
+              <Typography variant='body1' >{planter.phone || '---'}</Typography>
+            </Grid>
+            <Divider/>
+            <Grid container direction='column' className={classes.box}>
+              <Typography variant='subtitle1' >Person ID</Typography>
+              <Typography variant='body1' >{planter.personId || '---'}</Typography>
+            </Grid>
+            <Divider/>
+            <Grid container direction='column' className={classes.box}>
+              <Typography variant='subtitle1' >Organization</Typography>
+              <Typography variant='body1' >{planter.organization || '---' }</Typography>
+            </Grid>
+            <Divider />
+            <Grid container direction='column' className={classes.box}>
+              <Typography variant='subtitle1' >Organization ID</Typography>
+              <Typography variant='body1' >{planter.organizationId || '---'}</Typography>
+            </Grid>
+            <Divider />
+            <Grid container direction='column' className={classes.box}>
+              <Typography variant='subtitle1' >Registered</Typography>
+              <Typography variant='body1' >
+                {(planterRegistration && getDateTimeStringLocale(planterRegistration.createdAt)) || '---'}
+              </Typography>
+            </Grid>
           </Grid>
         </Grid>
-      </Grid>
-    </Drawer>
+      </Drawer>
+      {/* TODO: Reload planter details on save */}
+      <EditPlanter isOpen={editDialogOpen} planter={planter} onClose={handleEditClose}></EditPlanter>
+    </React.Fragment>
   )
 }
 

--- a/client/src/components/Planters.js
+++ b/client/src/components/Planters.js
@@ -146,6 +146,18 @@ const Planters = (props) => {
     })
   }, [props.plantersDispatch, props.plantersState.filter])
 
+  // Update PlanterDetail if the displayed planter changes
+  useEffect(() => {
+    if (isDetailShown) {
+      const planter = props.plantersState.planters.find((p) => p.id === planterDetail.id)
+      if (planter) {
+        setPlanterDetail(planter)
+      }
+    }
+  },
+  // eslint-disable-next-line
+  [props.plantersState.planters])
+
   function handlePlanterClick(planter){
     setDetailShown(true);
     setPlanterDetail(planter);

--- a/client/src/components/Planters.js
+++ b/client/src/components/Planters.js
@@ -146,18 +146,6 @@ const Planters = (props) => {
     })
   }, [props.plantersDispatch, props.plantersState.filter])
 
-  // Update PlanterDetail if the displayed planter changes
-  useEffect(() => {
-    if (isDetailShown) {
-      const planter = props.plantersState.planters.find((p) => p.id === planterDetail.id)
-      if (planter) {
-        setPlanterDetail(planter)
-      }
-    }
-  },
-  // eslint-disable-next-line
-  [props.plantersState.planters])
-
   function handlePlanterClick(planter){
     setDetailShown(true);
     setPlanterDetail(planter);
@@ -272,7 +260,7 @@ const Planters = (props) => {
           </Grid>
         </Grid>
       </Grid>
-      <PlanterDetail open={isDetailShown} planter={planterDetail} onClose={() => setDetailShown(false)} />
+      <PlanterDetail open={isDetailShown} planterId={planterDetail.id} onClose={() => setDetailShown(false)} />
     </React.Fragment>
   )
 }

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -279,23 +279,16 @@ const TreeImageScrubber = (props) => {
   async function handlePlanterDetail(e, tree) {
     e.preventDefault();
     e.stopPropagation();
-    let planter = props.plantersState.planters.find(x => x.id === tree.planterId);
-    if (!planter) {
-      planter = await props.plantersDispatch.getPlanter({ id: tree.planterId });
-    }
-    if (!planter) {
-      window.alert(`Planter not found id:${tree.planterId}`)
-    }
     setPlanterDetail({
       isOpen: true,
-      planter: planter,
+      planterId: tree.planterId,
     });
   }
 
   function handlePlanterDetailClose() {
     setPlanterDetail({
       isOpen: false,
-      planter: {},
+      planterId: null,
     })
   }
 
@@ -552,7 +545,7 @@ const TreeImageScrubber = (props) => {
         )}
       <PlanterDetail
         open={planterDetail.isOpen}
-        planter={planterDetail.planter}
+        planterId={planterDetail.planterId}
         onClose={() => handlePlanterDetailClose()}
       />
       <TreeDetailDialog

--- a/client/src/models/planters.js
+++ b/client/src/models/planters.js
@@ -64,7 +64,6 @@ const planters = {
       if (!planter) {
         // Otherwise query the API
         planter = await api.getPlanter(id);
-        this.setPlanters([planter, ...state.planters.planters]);
       }
       return planter;
     },

--- a/client/src/models/planters.js
+++ b/client/src/models/planters.js
@@ -58,10 +58,14 @@ const planters = {
      * }
      */
     async getPlanter(payload, state){
-      this.setIsLoading(true);
-      const planter = await api.getPlanter(payload.id);
-      this.setPlanters([planter, ...state.planters.planters]);
-      this.setIsLoading(false);
+      const { id } = payload;
+      // Look for a match in the local model first
+      let planter = state.planters.planters.find(p => p.id === id);
+      if (!planter) {
+        // Otherwise query the API
+        planter = await api.getPlanter(id);
+        this.setPlanters([planter, ...state.planters.planters]);
+      }
       return planter;
     },
 

--- a/client/src/models/planters.js
+++ b/client/src/models/planters.js
@@ -85,10 +85,10 @@ const planters = {
       this.setIsLoading(false);
       return true;
     },
-    async changePageSize(payload, state){
+    async changePageSize(payload, _state){
       this.setPageSize(payload.pageSize);
     },
-    async count(payload, state){
+    async count(_payload, state){
       const {count} = await api.getCount({filter: state.planters.filter});
       this.setCount(count);
       return true;

--- a/client/src/models/planters.js
+++ b/client/src/models/planters.js
@@ -68,7 +68,7 @@ const planters = {
     async load(payload, state){
       this.setIsLoading(true);
       const filter = payload.filter || state.planters.filter || new FilterPlanter()
-      const pageNumber = payload.pageNumber === undefined ? state.payload.pageNumber : payload.pageNumber
+      const pageNumber = payload.pageNumber === undefined ? state.planters.currentPage : payload.pageNumber
       const planters = await api.getPlanters({
         skip: pageNumber * state.planters.pageSize,
         rowsPerPage: state.planters.pageSize,
@@ -88,6 +88,14 @@ const planters = {
       const {count} = await api.getCount({filter: state.planters.filter});
       this.setCount(count);
       return true;
+    },
+    async updatePlanter(payload, state) {
+      await api.updatePlanter(payload);
+      const updatedPlanter = await api.getPlanter(payload.id);
+      const index = state.planters.planters.findIndex((p) => p.id === updatedPlanter.id);
+      if (index >= 0) {
+        this.setPlanters(Object.assign([], state.planters.planters, {[index]: updatedPlanter}));
+      }
     },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "treetracker-admin",
-  "version": "2.4.4",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/src/models/planter.model.ts
+++ b/server/src/models/planter.model.ts
@@ -27,7 +27,7 @@ export class Planter extends Entity {
 
   @property({
     type: String,
-    required: true,
+    required: false,
     length: 30,
     postgresql: {
       columnName: 'first_name',
@@ -42,7 +42,7 @@ export class Planter extends Entity {
 
   @property({
     type: String,
-    required: true,
+    required: false,
     length: 30,
     postgresql: {
       columnName: 'last_name',

--- a/server/src/models/trees.model.ts
+++ b/server/src/models/trees.model.ts
@@ -335,6 +335,16 @@ export class Trees extends Entity {
   })
   plantingOrganizationId?: Number;
 
+  @property({
+    type: Number,
+    required: false,
+    postgresql: {
+      columnName: 'planter_photo_url',
+      dataType: 'character varying',
+    },
+  })
+  planterPhotoUrl?: Number;
+
   // Define well-known properties here
 
   // Indexer property to allow additional data


### PR DESCRIPTION
Resolves #333 

Created a new Edit Planter dialog accessible from the Planter Detail drawer to users with `super_permission` or `manage_planter` privileges.

As well as editing basic planter info, the dialog presents the user with the most recent planter images from their tree captures to select from.
The user can also assign the organization to the planter. Note that this does not replace the text entered for the organization by the planter, but sets `organization_id` in the planters table.

![Screenshot 2021-02-03 at 22 01 06](https://user-images.githubusercontent.com/5558838/106815133-53e54400-666b-11eb-96ef-c12fefc6ffb1.png)

![Screenshot 2021-02-03 at 21 55 40](https://user-images.githubusercontent.com/5558838/106814604-90647000-666a-11eb-909a-b801b4b5db27.png)
