### PR TITLE
fix: allow users to list organizations

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,7 @@
     "migrate": "node ./dist/migrate",
     "prestart": "npm run clean && npm run build",
     "start": "NODE_ENV=development node .",
-    "start:debug": "NODE_ENV=development DEBUG=loopback:*,express:* node .",
+    "start:debug": "NODE_ENV=development DEBUG=loopback:*,express:* node --inspect .",
     "startTest": "NODE_ENV=test npm run build && NODE_ENV=test DEBUG=loopback:* node ./dist/indexTest.js",
     "prepublishOnly": "npm run test",
     "test": "NODE_ENV=test jest --watchAll --runInBand",

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -411,7 +411,7 @@ const isAuth = async (req, res, next) => {
   //white list
   const url = req.originalUrl;
   const isDevEnvironment = utils.getEnvironment() === 'development';
-  const isApiExplorerReq = isDevEnvironment;
+  const isApiExplorerReq = isDevEnvironment && false; // TODO: find Loopback explorer identifier
   if (
     url === '/auth/login' ||
     url === '/auth/test' ||
@@ -585,6 +585,24 @@ const isAuth = async (req, res, next) => {
               });
               return;
             }
+          }
+        }
+      }
+
+      matcher = url.match(/\/api\/(organization\/(\d+)\/)?organizations.*/);
+      if (matcher) {
+        if (matcher[1]) {
+          return next();
+        } else {
+          //normal case
+          //organizational user can not visit it directly
+          if (organization && organization.id > 0) {
+            res.status(401).json({
+              error: new Error('No permission'),
+            });
+            return;
+          } else {
+            return next();
           }
         }
       }

--- a/server/src/js/auth.js
+++ b/server/src/js/auth.js
@@ -407,6 +407,14 @@ router.post('/init', async (req, res) => {
   }
 });
 
+const hasPermission = (userPolicies, allowedPolicies, orgReq, organization) => {
+  if (orgReq && organization && organization.id > 0) {
+    return false;
+  }
+
+  return (userPolicies.some((r) => allowedPolicies.some(p => r.name === p)))
+}
+
 const isAuth = async (req, res, next) => {
   //white list
   const url = req.originalUrl;
@@ -495,116 +503,52 @@ const isAuth = async (req, res, next) => {
         return next();
       }
 
-
       matcher = url.match(/\/api\/(organization\/(\d+)\/)?trees.*/);
       if (matcher) {
-        if (matcher[1]) {
-          //organization case
-          if (
-            policies.some(
-              (r) =>
-                r.name === POLICIES.SUPER_PERMISSION ||
-                r.name === POLICIES.LIST_TREE ||
-                r.name === POLICIES.APPROVE_TREE,
-            )
-          ) {
-            return next();
-          } else {
-            res.status(401).json({
-              error: new Error('No permission'),
-            });
-            return;
-          }
-        } else {
-          //normal case
-          //organizational user can not visit it directly
-          if (organization && organization.id > 0) {
-            res.status(401).json({
-              error: new Error('No permission'),
-            });
-            return;
-          }
-          if (
-            policies.some(
-              (r) =>
-                r.name === POLICIES.SUPER_PERMISSION ||
-                r.name === POLICIES.LIST_TREE ||
-                r.name === POLICIES.APPROVE_TREE,
-            )
-          ) {
-            return next();
-          } else {
-            res.status(401).json({
-              error: new Error('No permission'),
-            });
-            return;
-          }
+        if (hasPermission(
+          policies,
+          [POLICIES.SUPER_PERMISSION, POLICIES.LIST_TREE, POLICIES.APPROVE_TREE],
+          matcher[1],
+          organization)) {
+          return next();
         }
+
+        res.status(401).json({
+          error: new Error('No permission'),
+        })
+        return;
       }
 
       matcher = url.match(/\/api\/(organization\/(\d+)\/)?planter.*/);
       if (matcher) {
-        if (matcher[1]) {
-          //organization case
-          if (
-            policies.some(
-              (r) =>
-                r.name === POLICIES.SUPER_PERMISSION ||
-                r.name === POLICIES.LIST_PLANTER ||
-                r.name === POLICIES.MANAGE_PLANTER,
-            )
-          ) {
-            return next();
-          } else {
-            res.status(401).json({
-              error: new Error('No permission'),
-            });
-            return;
-          }
-        } else {
-          //normal case
-          //organizational user can not visit it directly
-          if (organization && organization.id > 0) {
-            res.status(401).json({
-              error: new Error('No permission'),
-            });
-            return;
-          } else {
-            if (
-              policies.some(
-                (r) =>
-                  r.name === POLICIES.SUPER_PERMISSION ||
-                  r.name === POLICIES.LIST_PLANTER ||
-                  r.name === POLICIES.MANAGE_PLANTER,
-              )
-            ) {
-              return next();
-            } else {
-              res.status(401).json({
-                error: new Error('No permission'),
-              });
-              return;
-            }
-          }
+        if (hasPermission(
+          policies,
+          [POLICIES.SUPER_PERMISSION, POLICIES.LIST_PLANTER, POLICIES.MANAGE_PLANTER],
+          matcher[1],
+          organization)) {
+          return next();
         }
+
+        res.status(401).json({
+          error: new Error('No permission'),
+        })
+        return;
       }
 
       matcher = url.match(/\/api\/(organization\/(\d+)\/)?organizations.*/);
       if (matcher) {
-        if (matcher[1]) {
+        if (hasPermission(
+          policies,
+          [POLICIES.SUPER_PERMISSION, POLICIES.LIST_TREE, POLICIES.APPROVE_TREE, POLICIES.MANAGE_PLANTER],
+          matcher[1],
+          organization)) {
           return next();
-        } else {
-          //normal case
-          //organizational user can not visit it directly
-          if (organization && organization.id > 0) {
-            res.status(401).json({
-              error: new Error('No permission'),
-            });
-            return;
-          } else {
-            return next();
-          }
         }
+
+        res.status(401).json({
+          error: new Error('No permission'),
+        })
+        return;
       }
     } else {
       return next();

--- a/server/src/js/auth.test.js
+++ b/server/src/js/auth.test.js
@@ -380,6 +380,22 @@ describe('auth', () => {
 
       });
 
+      describe("/api/organizations", () => {
+
+        it("Successfully", async () => {
+            const jwt = require("jsonwebtoken");
+            jwt.verify.mockReturnValueOnce({policy:{
+              policies: [1,],
+              passwordHash: "testHash",
+            }});
+            query.mockResolvedValue({rows:[{}]});
+            auth.helper.getActiveAdminUserRoles = jest.fn(() => Promise.resolve({rows:[{passwordHasht:"testHash"}]}));
+            const response = await request(app).get('/api/organizations');
+            expect(response.statusCode).toBe(200);
+        });
+      });
+
+
     });
 
   });

--- a/server/src/js/auth.test.js
+++ b/server/src/js/auth.test.js
@@ -380,12 +380,14 @@ describe('auth', () => {
 
       });
 
-      describe("/api/organizations", () => {
+      describe("organizations", () => {
 
-        it("Successfully", async () => {
+        it("/planter successfully", async () => {
             const jwt = require("jsonwebtoken");
             jwt.verify.mockReturnValueOnce({policy:{
-              policies: [1,],
+              policies: [{
+                name: "list_tree",
+              }],
               passwordHash: "testHash",
             }});
             query.mockResolvedValue({rows:[{}]});
@@ -393,6 +395,34 @@ describe('auth', () => {
             const response = await request(app).get('/api/organizations');
             expect(response.statusCode).toBe(200);
         });
+
+        it("/planter 401 no permission", async () => {
+            const jwt = require("jsonwebtoken");
+            jwt.verify.mockReturnValueOnce({policy:{
+              policies: [{
+              }],
+              passwordHash: "testHash",
+            }});
+            query.mockResolvedValue({rows:[{}]});
+            auth.helper.getActiveAdminUserRoles = jest.fn(() => Promise.resolve({rows:[{passwordHasht:"testHash"}]}));
+            const response = await request(app).get('/api/organizations');
+            expect(response.statusCode).toBe(401);
+        });
+
+        it("/organization/planter successfully", async () => {
+            const jwt = require("jsonwebtoken");
+            jwt.verify.mockReturnValueOnce({policy:{
+              policies: [{
+                name: "manage_planter",
+              }],
+              passwordHash: "testHash",
+            }});
+            query.mockResolvedValue({rows:[{}]});
+            auth.helper.getActiveAdminUserRoles = jest.fn(() => Promise.resolve({rows:[{passwordHasht:"testHash"}]}));
+            const response = await request(app).get('/api/organization/1/organizations');
+            expect(response.statusCode).toBe(200);
+        });
+
       });
 
 


### PR DESCRIPTION
Resolves #509 

Users with `list_tree`, `approve_tree`, `manage_planter` or `super_user` permissions can access `/api/organizations` endpoint so that organizations can be listed in the _Verify_ and _Edit Planter_ tools.
