### PR TITLE
chore: fix the boolean env variable in deployment

### DIFF
--- a/server/deployment/base/treetracker-admin-api-deployment.yaml
+++ b/server/deployment/base/treetracker-admin-api-deployment.yaml
@@ -36,4 +36,4 @@ spec:
                 name: treetracker-rabbitmq-connection
                 key: messageQueue
           - name: ENABLE_VERIFY_PUBLISHING
-            value: true
+            value: "true"


### PR DESCRIPTION
Set the boolean feature flag env variable as a string value in deployment file.  This is to fix a failing deployment.