### PR TITLE
fix: species cleared on approval

### DIFF
--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -225,11 +225,6 @@ const TreeImageScrubber = (props) => {
     window.open(url, '_blank').opener = null;
   }
 
-  function resetApprovalFields() {
-    props.tagDispatch.setTagInput([])
-    props.speciesDispatch.setSpeciesInput('')
-  }
-
   async function handleSubmit(approveAction) {
     console.log('approveAction:', approveAction)
     //check selection
@@ -270,8 +265,6 @@ const TreeImageScrubber = (props) => {
     const result = await props.verityDispatch.approveAll({ approveAction });
     if (!result) {
       window.alert('sorry, failed to approve some picture');
-    } else {
-      resetApprovalFields();
     }
     props.verityDispatch.loadTreeImages();
   }

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -166,7 +166,7 @@ const useStyles = makeStyles(theme => ({
 
 }));
 
-const ToVerifyCounter = withData(({data}) => <>{data !== null && `${data} trees to verify`}</>);
+const ToVerifyCounter = withData(({ data }) => <>{data !== null && `${data} trees to verify`}</>);
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="up" ref={ref} {...props} />;
@@ -237,7 +237,7 @@ const TreeImageScrubber = (props) => {
      */
     const isNew = await props.speciesDispatch.isNewSpecies()
     if (isNew) {
-      const answer = await new Promise((resolve, reject) => {
+      const answer = await new Promise((resolve) => {
         if (window.confirm(`The species ${props.speciesState.speciesInput} is a new one, create it?`)) {
           resolve(true)
         } else {
@@ -301,7 +301,7 @@ const TreeImageScrubber = (props) => {
     })
   }
 
-  function handleChangePageSize(event, value) {
+  function handleChangePageSize(event) {
     props.verityDispatch.set({ pageSize: event.target.value });
   }
 
@@ -459,7 +459,7 @@ const TreeImageScrubber = (props) => {
                     <Typography variant='h5'>
                       <ToVerifyCounter needsRefresh={props.verityState.invalidateTreeCount}
                         fetch={props.verityDispatch.getTreeCount}
-                        data={props.verityState.treeCount}/>
+                        data={props.verityState.treeCount} />
                     </Typography>
                   </Grid>
                   <Grid item>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "treetracker-admin",
-  "version": "2.10.0",
+  "version": "2.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Resolves #521 

Species and tags are no longer cleared when a user clicks _Submit_.
This supports typical workflow of assigning species tags in batches.

https://user-images.githubusercontent.com/5558838/108272800-9b3efa80-716a-11eb-9ef9-057bfb633b38.mov

