### PR TITLE
feat: add image optimization to /verify and /planters

### DIFF
--- a/client/src/components/OptimizedImage.js
+++ b/client/src/components/OptimizedImage.js
@@ -1,0 +1,56 @@
+import React from 'react';
+
+export default function OptimizedImage(props) {
+  const {
+    src,
+    width = 320,
+    height,
+    quality,
+    screenWidths = [1600, 1280, 960, 0],
+    imageSizes = [400, 300, 250, 200],
+    fixed,
+    ...rest
+  } = props;
+
+  if (!src) return <></>;
+
+  const cdnPath = 'https://cdn.statically.io/img';
+  const domain = src.match(/\/\/(.*)\//)[1];
+  const imagePath = src.match(/.com\/(.*)/)[1];
+  const params =
+    `f=auto,w=${width}` +
+    (height ? `,h=${height}` : '') +
+    (quality ? `,q=${quality}` : '');
+
+  const cdnUrl = `${cdnPath}/${domain}/${params}/${imagePath}`;
+
+  let sizes, srcSet;
+  if (!fixed && screenWidths.length === imageSizes.length) {
+    sizes = screenWidths
+      .map((size, i) => `(min-width: ${size}px) ${imageSizes[i]}px`)
+      .join(', ');
+    srcSet = imageSizes
+      .map((size) => `${cdnPath}/${domain}/${params}/${imagePath} ${size}w`)
+      .join(', ');
+  }
+
+  return (
+    <>
+      <img
+        src={cdnUrl}
+        alt=".."
+        srcSet={srcSet}
+        sizes={sizes}
+        loading="lazy"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          objectFit: 'cover',
+          width: '100%',
+          height: '100%',
+        }}
+        {...rest}
+      />
+    </>
+  );
+}

--- a/client/src/components/PlanterDetail.js
+++ b/client/src/components/PlanterDetail.js
@@ -1,24 +1,25 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { makeStyles } from '@material-ui/core/styles'
-import Typography from '@material-ui/core/Typography'
-import CardMedia from '@material-ui/core/CardMedia'
-import Grid from '@material-ui/core/Grid'
-import IconButton from '@material-ui/core/IconButton'
-import Box from '@material-ui/core/Box'
-import Drawer from '@material-ui/core/Drawer'
-import Close from '@material-ui/icons/Close'
-import Person from '@material-ui/icons/Person'
-import Divider from '@material-ui/core/Divider'
-import EditIcon from '@material-ui/icons/Edit'
-import Fab from '@material-ui/core/Fab'
+import React from 'react';
+import { connect } from 'react-redux';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import CardMedia from '@material-ui/core/CardMedia';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
+import Box from '@material-ui/core/Box';
+import Drawer from '@material-ui/core/Drawer';
+import Close from '@material-ui/icons/Close';
+import Person from '@material-ui/icons/Person';
+import Divider from '@material-ui/core/Divider';
+import EditIcon from '@material-ui/icons/Edit';
+import Fab from '@material-ui/core/Fab';
 import api from '../api/planters';
-import { getDateTimeStringLocale } from '../common/locale'
-import { hasPermission, POLICIES } from '../models/auth'
-import { AppContext } from './Context'
-import EditPlanter from './EditPlanter'
+import { getDateTimeStringLocale } from '../common/locale';
+import { hasPermission, POLICIES } from '../models/auth';
+import { AppContext } from './Context';
+import EditPlanter from './EditPlanter';
+import OptimizedImage from './OptimizedImage';
 
-const useStyle = makeStyles(theme => ({
+const useStyle = makeStyles((theme) => ({
   root: {
     width: 441,
   },
@@ -51,61 +52,71 @@ const useStyle = makeStyles(theme => ({
   },
   imageContainer: {
     position: 'relative',
-  }
+    height: '378px',
+  },
 }));
 
 const PlanterDetail = (props) => {
-  
-  const [planterRegistration, setPlanterRegistration] = React.useState(null)
-  const [editDialogOpen, setEditDialogOpen] = React.useState(false)
-  const [planter, setPlanter] = React.useState({})
-  const classes = useStyle()
-  const { planterId } = props
-  const { user } = React.useContext(AppContext)
+  const [planterRegistration, setPlanterRegistration] = React.useState(null);
+  const [editDialogOpen, setEditDialogOpen] = React.useState(false);
+  const [planter, setPlanter] = React.useState({});
+  const classes = useStyle();
+  const { planterId } = props;
+  const { user } = React.useContext(AppContext);
 
   React.useEffect(() => {
     async function loadPlanterDetail() {
       if (planter && planter.id !== planterId) {
-        setPlanter({})
+        setPlanter({});
       }
 
       if (planterId) {
-        const match = await props.plantersDispatch.getPlanter({id: planterId})
-        setPlanter(match)
+        const match = await props.plantersDispatch.getPlanter({
+          id: planterId,
+        });
+        setPlanter(match);
 
-        if (!planterRegistration || planterRegistration.planterId !== planterId) {
-          setPlanterRegistration(null)
-          api.getPlanterRegistrations(planterId).then(registrations => {
+        if (
+          !planterRegistration ||
+          planterRegistration.planterId !== planterId
+        ) {
+          setPlanterRegistration(null);
+          api.getPlanterRegistrations(planterId).then((registrations) => {
             if (registrations && registrations.length) {
-              setPlanterRegistration(registrations[0])
+              setPlanterRegistration(registrations[0]);
             }
-          })
+          });
         }
       }
     }
 
-    loadPlanterDetail()
-  // eslint-disable-next-line
-  }, [planterId, planterRegistration, props.plantersState.planters, props.plantersDispatch])
-    
+    loadPlanterDetail();
+    // eslint-disable-next-line
+  }, [
+    planterId,
+    planterRegistration,
+    props.plantersState.planters,
+    props.plantersDispatch,
+  ]);
+
   function handleEditClick() {
-    setEditDialogOpen(true)
+    setEditDialogOpen(true);
   }
 
   function handleEditClose() {
-    setEditDialogOpen(false)
+    setEditDialogOpen(false);
   }
 
-  return(
+  return (
     <React.Fragment>
-      <Drawer anchor='right' open={props.open} onClose={props.onClose}>
-        <Grid className={classes.root} >
-          <Grid container direction='column'>
+      <Drawer anchor="right" open={props.open} onClose={props.onClose}>
+        <Grid className={classes.root}>
+          <Grid container direction="column">
             <Grid item>
-              <Grid container justify='space-between' alignItems='center' >
+              <Grid container justify="space-between" alignItems="center">
                 <Grid item>
-                  <Box m={4} >
-                    <Typography color='primary' variant='h6' >
+                  <Box m={4}>
+                    <Typography color="primary" variant="h6">
                       Planter Detail
                     </Typography>
                   </Box>
@@ -118,69 +129,92 @@ const PlanterDetail = (props) => {
               </Grid>
             </Grid>
             <Grid item className={classes.imageContainer}>
-              {planter.imageUrl &&
-                <CardMedia className={classes.cardMedia} image={planter.imageUrl} />
-              }
-              {!planter.imageUrl &&
-                <CardMedia className={classes.cardMedia} >
-                  <Grid container className={classes.personBox} >
+              {planter.imageUrl && (
+                <OptimizedImage
+                  src={planter.imageUrl}
+                  width={441}
+                  height={378}
+                  className={classes.cardMedia}
+                  fixed
+                />
+              )}
+              {!planter.imageUrl && (
+                <CardMedia className={classes.cardMedia}>
+                  <Grid container className={classes.personBox}>
                     <Person className={classes.person} />
                   </Grid>
                 </CardMedia>
-              }
-              {hasPermission(user, [POLICIES.SUPER_PERMISSION, POLICIES.MANAGE_PLANTER]) &&
+              )}
+              {hasPermission(user, [
+                POLICIES.SUPER_PERMISSION,
+                POLICIES.MANAGE_PLANTER,
+              ]) && (
                 <Fab
                   className={classes.editButton}
                   onClick={() => handleEditClick()}
                 >
                   <EditIcon />
                 </Fab>
-              }
+              )}
             </Grid>
-            <Grid item className={classes.box} >
-              <Typography variant='h5' color='primary' className={classes.name} >{planter.firstName} {planter.lastName}</Typography>
-              <Typography variant='body2'>ID:{planter.id}</Typography>
-            </Grid>
-            <Divider/>
-            <Grid container direction='column' className={classes.box}>
-              <Typography variant='subtitle1' >Email address</Typography>
-              <Typography variant='body1' >{planter.email || '---'}</Typography>
-            </Grid>
-            <Divider/>
-            <Grid container direction='column' className={classes.box}>
-              <Typography variant='subtitle1' >Phone number</Typography>
-              <Typography variant='body1' >{planter.phone || '---'}</Typography>
-            </Grid>
-            <Divider/>
-            <Grid container direction='column' className={classes.box}>
-              <Typography variant='subtitle1' >Person ID</Typography>
-              <Typography variant='body1' >{planter.personId || '---'}</Typography>
-            </Grid>
-            <Divider/>
-            <Grid container direction='column' className={classes.box}>
-              <Typography variant='subtitle1' >Organization</Typography>
-              <Typography variant='body1' >{planter.organization || '---' }</Typography>
+            <Grid item className={classes.box}>
+              <Typography variant="h5" color="primary" className={classes.name}>
+                {planter.firstName} {planter.lastName}
+              </Typography>
+              <Typography variant="body2">ID:{planter.id}</Typography>
             </Grid>
             <Divider />
-            <Grid container direction='column' className={classes.box}>
-              <Typography variant='subtitle1' >Organization ID</Typography>
-              <Typography variant='body1' >{planter.organizationId || '---'}</Typography>
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1">Email address</Typography>
+              <Typography variant="body1">{planter.email || '---'}</Typography>
             </Grid>
             <Divider />
-            <Grid container direction='column' className={classes.box}>
-              <Typography variant='subtitle1' >Registered</Typography>
-              <Typography variant='body1' >
-                {(planterRegistration && getDateTimeStringLocale(planterRegistration.createdAt)) || '---'}
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1">Phone number</Typography>
+              <Typography variant="body1">{planter.phone || '---'}</Typography>
+            </Grid>
+            <Divider />
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1">Person ID</Typography>
+              <Typography variant="body1">
+                {planter.personId || '---'}
+              </Typography>
+            </Grid>
+            <Divider />
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1">Organization</Typography>
+              <Typography variant="body1">
+                {planter.organization || '---'}
+              </Typography>
+            </Grid>
+            <Divider />
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1">Organization ID</Typography>
+              <Typography variant="body1">
+                {planter.organizationId || '---'}
+              </Typography>
+            </Grid>
+            <Divider />
+            <Grid container direction="column" className={classes.box}>
+              <Typography variant="subtitle1">Registered</Typography>
+              <Typography variant="body1">
+                {(planterRegistration &&
+                  getDateTimeStringLocale(planterRegistration.createdAt)) ||
+                  '---'}
               </Typography>
             </Grid>
           </Grid>
         </Grid>
       </Drawer>
-      <EditPlanter isOpen={editDialogOpen} planter={planter} onClose={handleEditClose}></EditPlanter>
+      <EditPlanter
+        isOpen={editDialogOpen}
+        planter={planter}
+        onClose={handleEditClose}
+      ></EditPlanter>
     </React.Fragment>
-  )
-}
-export { PlanterDetail }
+  );
+};
+export { PlanterDetail };
 
 export default connect(
   (state) => ({
@@ -188,5 +222,5 @@ export default connect(
   }),
   (dispatch) => ({
     plantersDispatch: dispatch.planters,
-  }),
-)(PlanterDetail)
+  })
+)(PlanterDetail);

--- a/client/src/components/Planters.js
+++ b/client/src/components/Planters.js
@@ -1,28 +1,29 @@
 /*
  * Planter page
  */
-import React, {useEffect} from 'react'
-import clsx from 'clsx'
-import {connect} from 'react-redux'
-import {makeStyles} from '@material-ui/core/styles'
-import Typography from '@material-ui/core/Typography'
-import Card from '@material-ui/core/Card'
-import CardActions from '@material-ui/core/CardActions'
-import CardContent from '@material-ui/core/CardContent'
-import CardMedia from '@material-ui/core/CardMedia'
-import TablePagination from '@material-ui/core/TablePagination'
+import React, { useEffect } from 'react';
+import clsx from 'clsx';
+import { connect } from 'react-redux';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import TablePagination from '@material-ui/core/TablePagination';
 
-import {selectedHighlightColor} from '../common/variables.js'
-import Grid from '@material-ui/core/Grid'
-import IconFilter from '@material-ui/icons/FilterList'
-import IconButton from '@material-ui/core/IconButton'
+import { selectedHighlightColor } from '../common/variables.js';
+import Grid from '@material-ui/core/Grid';
+import IconFilter from '@material-ui/icons/FilterList';
+import IconButton from '@material-ui/core/IconButton';
 
-import FilterTopPlanter from './FilterTopPlanter'
-import Person from "@material-ui/icons/Person";
-import Navbar from "./Navbar";
-import PlanterDetail from "./PlanterDetail"
+import FilterTopPlanter from './FilterTopPlanter';
+import Person from '@material-ui/icons/Person';
+import Navbar from './Navbar';
+import PlanterDetail from './PlanterDetail';
+import OptimizedImage from './OptimizedImage';
 
-const log = require('loglevel').getLogger('../components/Planters')
+const log = require('loglevel').getLogger('../components/Planters');
 
 const useStyles = makeStyles((theme) => ({
   outer: {
@@ -46,6 +47,8 @@ const useStyles = makeStyles((theme) => ({
   },
   cardContent: {
     padding: 0,
+    height: '12rem',
+    position: 'relative',
   },
   selected: {
     border: `2px ${selectedHighlightColor} solid`,
@@ -58,8 +61,8 @@ const useStyles = makeStyles((theme) => ({
   },
   planterCard: {
     borderRadius: 16,
-    border: "1px solid rgba(0, 0, 0, 0.12)",
-    boxShadow: "none",
+    border: '1px solid rgba(0, 0, 0, 0.12)',
+    boxShadow: 'none',
   },
   placeholderCard: {
     pointerEvents: 'none',
@@ -103,79 +106,82 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(2, 16),
   },
   personBox: {
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    backgroundColor: "lightgray",
-    height: "100%",
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'lightgray',
+    height: '100%',
   },
   person: {
     height: 90,
     width: 90,
-    fill: "gray",
+    fill: 'gray',
   },
   name: {
-    textTransform: "capitalize",
+    textTransform: 'capitalize',
   },
-}))
+}));
 
 const Planters = (props) => {
-  log.debug('render Planters...')
-  const classes = useStyles(props)
-  const [isFilterShown, setFilterShown] = React.useState(false)
-  const [isDetailShown, setDetailShown] = React.useState(false)
+  log.debug('render Planters...');
+  const classes = useStyles(props);
+  const [isFilterShown, setFilterShown] = React.useState(false);
+  const [isDetailShown, setDetailShown] = React.useState(false);
   const [planterDetail, setPlanterDetail] = React.useState({});
 
   /*
    * effect to load page when mounted
    */
   useEffect(() => {
-    log.debug('mounted')
-    props.plantersDispatch.count()
-  }, [props.plantersDispatch])
+    log.debug('mounted');
+    props.plantersDispatch.count();
+  }, [props.plantersDispatch]);
 
   useEffect(() => {
     props.plantersDispatch.load({
       pageNumber: 0,
     });
-  }, [props.plantersDispatch, props.plantersState.pageSize])
+  }, [props.plantersDispatch, props.plantersState.pageSize]);
 
   useEffect(() => {
     props.plantersDispatch.count({
       filter: props.plantersState.filter,
-    })
-  }, [props.plantersDispatch, props.plantersState.filter])
+    });
+  }, [props.plantersDispatch, props.plantersState.filter]);
 
   function handlePlanterClick(planter) {
     setDetailShown(true);
     setPlanterDetail(planter);
   }
 
-  const placeholderPlanters = Array(props.plantersState.pageSize).fill().map((_, index) => {
-    return {
-      id: index,
-      placeholder: true,
-    };
-  });
+  const placeholderPlanters = Array(props.plantersState.pageSize)
+    .fill()
+    .map((_, index) => {
+      return {
+        id: index,
+        placeholder: true,
+      };
+    });
 
-  let plantersItems = (props.plantersState.isLoading ?
-    placeholderPlanters :
-    props.plantersState.planters
+  let plantersItems = (props.plantersState.isLoading
+    ? placeholderPlanters
+    : props.plantersState.planters
   ).map((planter) => {
     return (
       <Planter
         onClick={() => handlePlanterClick(planter)}
         key={planter.id}
         planter={planter}
-        placeholder={planter.placeholder} />
-    )
-  })
+        placeholder={planter.placeholder}
+      />
+    );
+  });
 
   function handleFilterClick() {
     if (isFilterShown) {
-      setFilterShown(false)
+      setFilterShown(false);
     } else {
-      setFilterShown(true)
+      setFilterShown(true);
     }
   }
 
@@ -187,7 +193,7 @@ const Planters = (props) => {
   }
 
   function handleChangePageSize(e, option) {
-    props.plantersDispatch.changePageSize({pageSize: option.props.value})
+    props.plantersDispatch.changePageSize({ pageSize: option.props.value });
   }
 
   function updateFilter(filter) {
@@ -218,23 +224,20 @@ const Planters = (props) => {
             buttons={[
               <IconButton onClick={handleFilterClick} key={1}>
                 <IconFilter />
-              </IconButton>
+              </IconButton>,
             ]}
           >
-            {isFilterShown &&
+            {isFilterShown && (
               <FilterTopPlanter
                 isOpen={isFilterShown}
-                onSubmit={filter => updateFilter(filter)}
+                onSubmit={(filter) => updateFilter(filter)}
                 filter={props.plantersState.filter}
                 onClose={handleFilterClick}
               />
-            }
+            )}
           </Navbar>
         </Grid>
-        <Grid
-          item
-          className={classes.body}
-        >
+        <Grid item className={classes.body}>
           <Grid container>
             <Grid
               item
@@ -242,69 +245,91 @@ const Planters = (props) => {
                 width: '100%',
               }}
             >
-              <Grid container justify='space-between' alignItems='center' className={classes.title}>
+              <Grid
+                container
+                justify="space-between"
+                alignItems="center"
+                className={classes.title}
+              >
                 <Grid item>
-                  <Typography variant='h5'>
-                    Planters
-                  </Typography>
+                  <Typography variant="h5">Planters</Typography>
                 </Grid>
                 <Grid item>{pagination}</Grid>
               </Grid>
             </Grid>
-            <Grid item container direction='row' justify='center'>
+            <Grid item container direction="row" justify="center">
               {plantersItems}
             </Grid>
           </Grid>
-          <Grid container className={classes.page} justify='flex-end' >
+          <Grid container className={classes.page} justify="flex-end">
             {pagination}
           </Grid>
         </Grid>
       </Grid>
-      <PlanterDetail open={isDetailShown} planterId={planterDetail.id} onClose={() => setDetailShown(false)} />
+      <PlanterDetail
+        open={isDetailShown}
+        planterId={planterDetail.id}
+        onClose={() => setDetailShown(false)}
+      />
     </React.Fragment>
-  )
-}
+  );
+};
 
 function Planter(props) {
-  const {
-    planter
-  } = props;
+  const { planter } = props;
   const classes = useStyles(props);
   return (
-    <div onClick={() => props.onClick()} className={clsx(classes.cardWrapper)} key={planter.id}>
+    <div
+      onClick={() => props.onClick()}
+      className={clsx(classes.cardWrapper)}
+      key={planter.id}
+    >
       <Card
         id={`card_${planter.id}`}
-        className={clsx(classes.card, props.placeholder && classes.placeholderCard)}
+        className={clsx(
+          classes.card,
+          props.placeholder && classes.placeholderCard
+        )}
         classes={{
           root: classes.planterCard,
         }}
       >
         <CardContent className={classes.cardContent}>
-          {planter.imageUrl &&
-            <CardMedia className={classes.cardMedia} image={planter.imageUrl} />
-          }
-          {!planter.imageUrl &&
-            <CardMedia className={classes.cardMedia} >
-              <Grid container className={classes.personBox} >
+          {planter.imageUrl && (
+            <OptimizedImage
+              src={planter.imageUrl}
+              width={182}
+              height={192}
+              className={classes.cardMedia}
+              fixed
+            />
+          )}
+          {!planter.imageUrl && (
+            <CardMedia className={classes.cardMedia}>
+              <Grid container className={classes.personBox}>
                 <Person className={classes.person} />
               </Grid>
             </CardMedia>
-          }
+          )}
         </CardContent>
         <CardActions className={classes.cardActions}>
-          <Grid justify="flex-start" container >
+          <Grid justify="flex-start" container>
             <Grid container direction="column">
-              <Typography className={classes.name} >{planter.firstName} {planter.lastName}</Typography>
+              <Typography className={classes.name}>
+                {planter.firstName} {planter.lastName}
+              </Typography>
               <Typography>ID: {planter.id}</Typography>
-              {planter.organization && <Typography>Organization: {planter.organization}</Typography>}
+              {planter.organization && (
+                <Typography>Organization: {planter.organization}</Typography>
+              )}
             </Grid>
           </Grid>
         </CardActions>
       </Card>
     </div>
-  )
+  );
 }
-export {Planter};
+export { Planter };
 
 export default connect(
   //state
@@ -315,4 +340,4 @@ export default connect(
   (dispatch) => ({
     plantersDispatch: dispatch.planters,
   })
-)(Planters)
+)(Planters);

--- a/client/src/components/TreeDetailDialog.js
+++ b/client/src/components/TreeDetailDialog.js
@@ -1,29 +1,30 @@
-import React, { Fragment, useRef, useState, useEffect } from 'react'
+import React, { Fragment, useRef, useState, useEffect } from 'react';
 
-import compose from 'recompose/compose'
-import { connect } from 'react-redux'
+import compose from 'recompose/compose';
+import { connect } from 'react-redux';
 
 import { makeStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography'
-import Dialog from '@material-ui/core/Dialog'
-import DialogActions from '@material-ui/core/DialogActions'
-import DialogContent from '@material-ui/core/DialogContent'
-import Grid from '@material-ui/core/Grid'
-import Divider from '@material-ui/core/Divider'
-import Chip from '@material-ui/core/Chip'
-import Button from '@material-ui/core/Button'
-import IconButton from '@material-ui/core/IconButton'
-import Snackbar from '@material-ui/core/Snackbar'
+import Typography from '@material-ui/core/Typography';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import Grid from '@material-ui/core/Grid';
+import Divider from '@material-ui/core/Divider';
+import Chip from '@material-ui/core/Chip';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import Snackbar from '@material-ui/core/Snackbar';
 
-import FileCopy from '@material-ui/icons/FileCopy'
-import CloseIcon from '@material-ui/icons/Close'
+import FileCopy from '@material-ui/icons/FileCopy';
+import CloseIcon from '@material-ui/icons/Close';
 
+import OptimizedImage from '../components/OptimizedImage';
 
 const useStyles = makeStyles((theme) => ({
   chipRoot: {
     display: 'flex',
     flexWrap: 'wrap',
-    margin: theme.spacing(0, -1)
+    margin: theme.spacing(0, -1),
   },
   chip: {
     margin: theme.spacing(0.5),
@@ -32,93 +33,96 @@ const useStyles = makeStyles((theme) => ({
   copyButton: {
     margin: theme.spacing(-2, 0),
   },
-}))
+}));
 
 function TreeDetailDialog(props) {
-  const { open, TransitionComponent, tree } = props
+  const { open, TransitionComponent, tree } = props;
 
-  const [snackbarOpen, setSnackbarOpen] = useState(false)
-  const [snackbarLabel, setSnackbarLabel] = useState('')
-  const [renderTree, setRenderTree] = useState(tree)
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarLabel, setSnackbarLabel] = useState('');
+  const [renderTree, setRenderTree] = useState(tree);
   const classes = useStyles();
   const textAreaRef = useRef(null);
 
   useEffect(() => {
-    props.treeDetailDispatch.getTreeDetail(props.tree.id)
-  }, [props.treeDetailDispatch, props.tree])
+    props.treeDetailDispatch.getTreeDetail(props.tree.id);
+  }, [props.treeDetailDispatch, props.tree]);
 
   /*
    * Render the most complete tree detail we have
    */
   useEffect(() => {
     if (props.treeDetail.tree) {
-      setRenderTree(props.treeDetail.tree)
+      setRenderTree(props.treeDetail.tree);
     } else {
-      setRenderTree(props.tree)
+      setRenderTree(props.tree);
     }
-  }, [props.treeDetail, props.tree])
+  }, [props.treeDetail, props.tree]);
 
   function handleClose() {
-    setSnackbarOpen(false)
-    setSnackbarLabel('')
-    props.treeDetailDispatch.reset()
-    props.onClose()
+    setSnackbarOpen(false);
+    setSnackbarLabel('');
+    props.treeDetailDispatch.reset();
+    props.onClose();
   }
 
   function Tags(props) {
-    const { tree, species, treeTags } = props
+    const { tree, species, treeTags } = props;
     const allTags = [
       tree.morphology,
       tree.age,
       tree.captureApprovalTag,
       tree.rejectionReason,
-      ...treeTags.map(t => t.tagName)
-    ]
-      .filter(tag => !!tag)
+      ...treeTags.map((t) => t.tagName),
+    ].filter((tag) => !!tag);
 
-    const dateCreated = new Date(Date.parse(tree.timeCreated))
+    const dateCreated = new Date(Date.parse(tree.timeCreated));
     function confirmCopy(label) {
-      setSnackbarOpen(false)
-      setSnackbarLabel(label)
-      setSnackbarOpen(true)
+      setSnackbarOpen(false);
+      setSnackbarLabel(label);
+      setSnackbarOpen(true);
     }
 
     function handleSnackbarClose(event, reason) {
       if (reason === 'clickaway') {
-        return
+        return;
       }
-      setSnackbarOpen(false)
+      setSnackbarOpen(false);
     }
 
     function CopyButton(props) {
-      const { value, label } = props
+      const { value, label } = props;
 
       return (
         <IconButton
           className={classes.copyButton}
-          title='Copy to clipboard'
+          title="Copy to clipboard"
           onClick={() => {
-            navigator.clipboard.writeText(value)
-            confirmCopy(label)
+            navigator.clipboard.writeText(value);
+            confirmCopy(label);
           }}
         >
-          <FileCopy fontSize='small' />
+          <FileCopy fontSize="small" />
         </IconButton>
-      )
+      );
     }
 
     return (
-      <Grid item container direction='column' spacing={4}>
+      <Grid item container direction="column" spacing={4}>
         <Grid item>
-          <Typography color='primary' variant='h6'>
+          <Typography color="primary" variant="h6">
             {`Tree ${tree.id}`}
-            <CopyButton label='Tree ID' value={tree.id} />
+            <CopyButton label="Tree ID" value={tree.id} />
           </Typography>
         </Grid>
         <Divider />
         {[
           { label: 'Planter ID', value: tree.planterId, copy: true },
-          { label: 'Planter Identifier', value: tree.planterIdentifier, copy: true },
+          {
+            label: 'Planter Identifier',
+            value: tree.planterIdentifier,
+            copy: true,
+          },
           { label: 'Device ID', value: tree.deviceId, copy: true },
           { label: 'Approved', value: tree.approved ? 'true' : 'false' },
           { label: 'Active', value: tree.active ? 'true' : 'false' },
@@ -126,30 +130,31 @@ function TreeDetailDialog(props) {
           { label: 'Species', value: species && species.name },
           { label: 'Created', value: dateCreated.toLocaleString() },
           { label: 'Note', value: renderTree.note },
-        ].map(item =>
+        ].map((item) => (
           <Fragment key={item.label}>
             <Grid item>
-              <Typography variant='subtitle1'>{item.label}</Typography>
-              <Typography variant='body1'>
+              <Typography variant="subtitle1">{item.label}</Typography>
+              <Typography variant="body1">
                 {item.value || '---'}
-                {item.value && item.copy &&
+                {item.value && item.copy && (
                   <CopyButton label={item.label} value={item.value} />
-                }
+                )}
               </Typography>
             </Grid>
             <Divider />
           </Fragment>
-        )}
+        ))}
         <Grid item>
-          <Typography variant='subtitle1'>
-            Tags
-          </Typography>
-          {
-            allTags.length === 0 ? <Typography variant='body1'>---</Typography> :
-              <div className={classes.chipRoot}>
-                {allTags.map(tag => <Chip key={tag} label={tag} className={classes.chip} />)}
-              </div>
-          }
+          <Typography variant="subtitle1">Tags</Typography>
+          {allTags.length === 0 ? (
+            <Typography variant="body1">---</Typography>
+          ) : (
+            <div className={classes.chipRoot}>
+              {allTags.map((tag) => (
+                <Chip key={tag} label={tag} className={classes.chip} />
+              ))}
+            </div>
+          )}
         </Grid>
         <Snackbar
           anchorOrigin={{
@@ -161,17 +166,21 @@ function TreeDetailDialog(props) {
           autoHideDuration={2000}
           onClose={handleSnackbarClose}
           message={`${snackbarLabel} copied to clipboard`}
-          color='primary'
+          color="primary"
           action={
             <Fragment>
-              <IconButton size='small' aria-label='close' onClick={handleSnackbarClose}>
-                <CloseIcon fontSize='small' />
+              <IconButton
+                size="small"
+                aria-label="close"
+                onClick={handleSnackbarClose}
+              >
+                <CloseIcon fontSize="small" />
               </IconButton>
             </Fragment>
           }
         />
       </Grid>
-    )
+    );
   }
 
   return (
@@ -179,36 +188,45 @@ function TreeDetailDialog(props) {
       open={open}
       TransitionComponent={TransitionComponent}
       onClose={handleClose}
-      maxWidth='xl'
+      maxWidth="xl"
     >
       <DialogContent>
-        <Grid container spacing={4} wrap='nowrap'>
+        <Grid container spacing={4} wrap="nowrap">
           <Grid item>
-            <img alt={`Tree ${renderTree}`} style={{ maxWidth: '100%' }} src={renderTree.imageUrl} />
+            <OptimizedImage
+              src={renderTree.imageUrl}
+              width={480}
+              style={{ maxWidth: '100%' }}
+              fixed
+            />
           </Grid>
           <Grid container item style={{ width: '300px' }} spacing={2}>
-            <Grid container direction='row' spacing={4}>
-              <Tags tree={renderTree} species={props.treeDetail.species} treeTags={props.treeDetail.tags} />
+            <Grid container direction="row" spacing={4}>
+              <Tags
+                tree={renderTree}
+                species={props.treeDetail.species}
+                treeTags={props.treeDetail.tags}
+              />
             </Grid>
           </Grid>
         </Grid>
       </DialogContent>
-      <DialogActions justify='center'>
-        <Button onClick={handleClose} color='primary'>Close</Button>
+      <DialogActions justify="center">
+        <Button onClick={handleClose} color="primary">
+          Close
+        </Button>
       </DialogActions>
       <textarea ref={textAreaRef} hidden />
     </Dialog>
-  )
+  );
 }
 
 const mapState = (state) => ({
   treeDetail: state.treeDetail,
-})
+});
 
 const mapDispatch = (dispatch) => ({
   treeDetailDispatch: dispatch.treeDetail,
-})
+});
 
-export default compose(
-  connect(mapState, mapDispatch)
-)(TreeDetailDialog)
+export default compose(connect(mapState, mapDispatch))(TreeDetailDialog);

--- a/client/src/components/TreeImageScrubber.js
+++ b/client/src/components/TreeImageScrubber.js
@@ -6,7 +6,6 @@ import Typography from '@material-ui/core/Typography';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
-import CardMedia from '@material-ui/core/CardMedia';
 import Button from '@material-ui/core/Button'; // replace with icons down the line
 import Slide from '@material-ui/core/Slide';
 
@@ -31,29 +30,30 @@ import Species from './Species';
 import FilterTop from './FilterTop';
 import { ReactComponent as TreePin } from '../components/images/highlightedPinNoStick.svg';
 import CheckIcon from '@material-ui/icons/Check';
-import Person from "@material-ui/icons/Person";
+import Person from '@material-ui/icons/Person';
 import Paper from '@material-ui/core/Paper';
 import TablePagination from '@material-ui/core/TablePagination';
-import Navbar from "./Navbar";
-import PlanterDetail from "./PlanterDetail"
+import Navbar from './Navbar';
+import PlanterDetail from './PlanterDetail';
 import TreeTags from './TreeTags';
 import TreeDetailDialog from './TreeDetailDialog';
-import withData from './common/withData'
+import withData from './common/withData';
+import OptimizedImage from './OptimizedImage';
 
 const log = require('loglevel').getLogger('../components/TreeImageScrubber');
 
 const SIDE_PANEL_WIDTH = 315;
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   wrapper: {
-    padding: theme.spacing(2, 8, 4, 8)
+    padding: theme.spacing(2, 8, 4, 8),
   },
   cardImg: {
     width: '100%',
-    height: 'auto'
+    height: 'auto',
   },
   cardTitle: {
-    color: '#f00'
+    color: '#f00',
   },
   card: {
     cursor: 'pointer',
@@ -68,31 +68,31 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    zIndex: 1
+    zIndex: 1,
   },
   cardSelected: {
-    backgroundColor: theme.palette.action.selected
+    backgroundColor: theme.palette.action.selected,
   },
   cardContent: {
     padding: '87% 0 0 0',
-    position: 'relative'
+    position: 'relative',
   },
   selected: {
-    border: `2px ${selectedHighlightColor} solid`
+    border: `2px ${selectedHighlightColor} solid`,
   },
   cardMedia: {
     position: 'absolute',
     top: 0,
     bottom: 0,
     left: 0,
-    right: 0
+    right: 0,
   },
   cardWrapper: {
     position: 'relative',
     padding: theme.spacing(2),
     transition: theme.transitions.create('padding', {
       easing: theme.transitions.easing.easeInOut,
-      duration: '0.1s'
+      duration: '0.1s',
     }),
     '&:not($cardSelected):hover': {
       padding: 0,
@@ -108,20 +108,20 @@ const useStyles = makeStyles(theme => ({
     },
   },
   title: {
-    padding: theme.spacing(2, 8)
+    padding: theme.spacing(2, 8),
   },
   snackbar: {
-    bottom: 20
+    bottom: 20,
   },
   snackbarContent: {
-    backgroundColor: theme.palette.action.active
+    backgroundColor: theme.palette.action.active,
   },
   cardActions: {
     display: 'flex',
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
   },
   button: {
-    marginRight: '8px'
+    marginRight: '8px',
   },
 
   navbar: {
@@ -163,10 +163,11 @@ const useStyles = makeStyles(theme => ({
     paddingLeft: '16px',
     paddingRight: '16px',
   },
-
 }));
 
-const ToVerifyCounter = withData(({data}) => <>{data !== null && `${data} trees to verify`}</>);
+const ToVerifyCounter = withData(({ data }) => (
+  <>{data !== null && `${data} trees to verify`}</>
+));
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="up" ref={ref} {...props} />;
@@ -179,7 +180,10 @@ const TreeImageScrubber = (props) => {
   const [complete, setComplete] = React.useState(0);
   const [isFilterShown, setFilterShown] = React.useState(false);
   const [dialog, setDialog] = React.useState({ isOpen: false, tree: {} });
-  const [planterDetail, setPlanterDetail] = React.useState({ isOpen: false, planter: {} })
+  const [planterDetail, setPlanterDetail] = React.useState({
+    isOpen: false,
+    planter: {},
+  });
   const refContainer = React.useRef();
 
   /*
@@ -203,7 +207,11 @@ const TreeImageScrubber = (props) => {
   /* load more trees when the page or page size changes */
   useEffect(() => {
     props.verityDispatch.loadTreeImages();
-  }, [props.verityDispatch, props.verityState.pageSize, props.verityState.currentPage]);
+  }, [
+    props.verityDispatch,
+    props.verityState.pageSize,
+    props.verityState.currentPage,
+  ]);
 
   function handleTreeClick(e, treeId) {
     e.stopPropagation();
@@ -213,7 +221,7 @@ const TreeImageScrubber = (props) => {
       treeId,
       isShift: e.shiftKey,
       isCmd: e.metaKey,
-      isCtrl: e.ctrlKey
+      isCtrl: e.ctrlKey,
     });
   }
 
@@ -226,46 +234,50 @@ const TreeImageScrubber = (props) => {
   }
 
   function resetApprovalFields() {
-    props.tagDispatch.setTagInput([])
-    props.speciesDispatch.setSpeciesInput('')
+    props.tagDispatch.setTagInput([]);
+    props.speciesDispatch.setSpeciesInput('');
   }
 
   async function handleSubmit(approveAction) {
-    console.log('approveAction:', approveAction)
+    console.log('approveAction:', approveAction);
     //check selection
     if (props.verityState.treeImagesSelected.length === 0) {
-      window.alert('Please select some tree')
-      return
+      window.alert('Please select some tree');
+      return;
     }
     /*
      * check species
      */
-    const isNew = await props.speciesDispatch.isNewSpecies()
+    const isNew = await props.speciesDispatch.isNewSpecies();
     if (isNew) {
       const answer = await new Promise((resolve, reject) => {
-        if (window.confirm(`The species ${props.speciesState.speciesInput} is a new one, create it?`)) {
-          resolve(true)
+        if (
+          window.confirm(
+            `The species ${props.speciesState.speciesInput} is a new one, create it?`
+          )
+        ) {
+          resolve(true);
         } else {
-          resolve(false)
+          resolve(false);
         }
-      })
+      });
       if (!answer) {
-        return
+        return;
       } else {
         //create new species
-        await props.speciesDispatch.createSpecies()
+        await props.speciesDispatch.createSpecies();
       }
     }
-    const speciesId = await props.speciesDispatch.getSpeciesId()
+    const speciesId = await props.speciesDispatch.getSpeciesId();
     if (speciesId) {
-      approveAction.speciesId = speciesId
-      console.log('species id:', speciesId)
+      approveAction.speciesId = speciesId;
+      console.log('species id:', speciesId);
     }
 
     /*
      * create/retrieve tags
      */
-    approveAction.tags = await props.tagDispatch.createTags()
+    approveAction.tags = await props.tagDispatch.createTags();
 
     const result = await props.verityDispatch.approveAll({ approveAction });
     if (!result) {
@@ -289,7 +301,7 @@ const TreeImageScrubber = (props) => {
     setPlanterDetail({
       isOpen: false,
       planterId: null,
-    })
+    });
   }
 
   function handleDialog(e, tree) {
@@ -298,14 +310,14 @@ const TreeImageScrubber = (props) => {
     setDialog({
       isOpen: true,
       tree,
-    })
+    });
   }
 
   function handleDialogClose() {
     setDialog({
       isOpen: false,
-      tree: {}
-    })
+      tree: {},
+    });
   }
 
   function handleChangePageSize(event, value) {
@@ -317,84 +329,82 @@ const TreeImageScrubber = (props) => {
   }
 
   function isTreeSelected(id) {
-    return props.verityState.treeImagesSelected.indexOf(id) >= 0
+    return props.verityState.treeImagesSelected.indexOf(id) >= 0;
   }
 
   const treeImages = props.verityState.treeImages.filter((tree, index) => {
-    return index >= props.verityState.currentPage * props.verityState.pageSize &&
-      index < (props.verityState.currentPage + 1) * props.verityState.pageSize;
+    return (
+      index >= props.verityState.currentPage * props.verityState.pageSize &&
+      index < (props.verityState.currentPage + 1) * props.verityState.pageSize
+    );
   });
 
-  const placeholderImages =
-    props.verityState.isLoading ?
-      Array(props.verityState.pageSize - treeImages.length)
-        .fill().map((_, index) => {
+  const placeholderImages = props.verityState.isLoading
+    ? Array(props.verityState.pageSize - treeImages.length)
+        .fill()
+        .map((_, index) => {
           return {
             id: index,
             placeholder: true,
           };
         })
-      : [];
+    : [];
 
-  const treeImageItems = treeImages.concat(placeholderImages)
-    .map(tree => {
-      return (
-        <Grid item xs={12} sm={6} md={4} xl={3} key={tree.id}>
-          <div
-            className={clsx(
-              classes.cardWrapper,
-              isTreeSelected(tree.id)
-                ? classes.cardSelected
-                : undefined,
-              tree.placeholder && classes.placeholderCard
-            )}
+  const treeImageItems = treeImages.concat(placeholderImages).map((tree) => {
+    return (
+      <Grid item xs={12} sm={6} md={4} xl={3} key={tree.id}>
+        <div
+          className={clsx(
+            classes.cardWrapper,
+            isTreeSelected(tree.id) ? classes.cardSelected : undefined,
+            tree.placeholder && classes.placeholderCard
+          )}
+        >
+          {isTreeSelected(tree.id) && (
+            <Paper className={classes.cardCheckbox} elevation={4}>
+              <CheckIcon />
+            </Paper>
+          )}
+          <Card
+            onClick={(e) => handleTreeClick(e, tree.id)}
+            id={`card_${tree.id}`}
+            className={classes.card}
+            elevation={tree.placeholder ? 0 : 3}
           >
-            {isTreeSelected(tree.id) &&
-              (<Paper
-                className={classes.cardCheckbox}
-                elevation={4}
-              >
-                <CheckIcon />
-              </Paper>)
-            }
-            <Card
-              onClick={e => handleTreeClick(e, tree.id)}
-              id={`card_${tree.id}`}
-              className={classes.card}
-              elevation={tree.placeholder ? 0 : 3}
-            >
-              <CardContent className={classes.cardContent}>
-                {tree.imageUrl && <CardMedia className={classes.cardMedia} image={tree.imageUrl} />}
-              </CardContent>
-              <CardActions className={classes.cardActions}>
-                <Grid
-                  justify='flex-end'
-                  container>
-                  <Grid item>
-                    <Person
-                      color='primary'
-                      onClick={e => handlePlanterDetail(e, tree)}
-                    />
-                    <Image
-                      color='primary'
-                      onClick={e => handleDialog(e, tree)}
-                    />
-                    <TreePin
-                      width='25px'
-                      height='25px'
-                      title={`Open Webmap for Tree# ${tree.id}`}
-                      onClick={e => {
-                        handleTreePinClick(e, tree.id);
-                      }}
-                    />
-                  </Grid>
+            <CardContent className={classes.cardContent}>
+              <OptimizedImage
+                src={tree.imageUrl}
+                width={320}
+                className={classes.cardMedia}
+              />
+            </CardContent>
+            <CardActions className={classes.cardActions}>
+              <Grid justify="flex-end" container>
+                <Grid item>
+                  <Person
+                    color="primary"
+                    onClick={(e) => handlePlanterDetail(e, tree)}
+                  />
+                  <Image
+                    color="primary"
+                    onClick={(e) => handleDialog(e, tree)}
+                  />
+                  <TreePin
+                    width="25px"
+                    height="25px"
+                    title={`Open Webmap for Tree# ${tree.id}`}
+                    onClick={(e) => {
+                      handleTreePinClick(e, tree.id);
+                    }}
+                  />
                 </Grid>
-              </CardActions>
-            </Card>
-          </div>
-        </Grid>
-      );
-    });
+              </Grid>
+            </CardActions>
+          </Card>
+        </div>
+      </Grid>
+    );
+  });
 
   function handleFilterClick() {
     if (isFilterShown) {
@@ -427,19 +437,19 @@ const TreeImageScrubber = (props) => {
               buttons={[
                 <IconButton onClick={handleFilterClick} key={1}>
                   <IconFilter />
-                </IconButton>
+                </IconButton>,
               ]}
             >
-              {isFilterShown &&
+              {isFilterShown && (
                 <FilterTop
                   isOpen={isFilterShown}
-                  onSubmit={filter => {
+                  onSubmit={(filter) => {
                     props.verityDispatch.updateFilter(filter);
                   }}
                   filter={props.verityState.filter}
                   onClose={handleFilterClick}
                 />
-              }
+              )}
             </Navbar>
           </Grid>
           <Grid
@@ -458,50 +468,50 @@ const TreeImageScrubber = (props) => {
               >
                 <Grid
                   container
-                  justify='space-between'
-                  alignItems='center'
+                  justify="space-between"
+                  alignItems="center"
                   className={classes.title}
                 >
                   <Grid item>
-                    <Typography variant='h5'>
-                      <ToVerifyCounter needsRefresh={props.verityState.invalidateTreeCount}
+                    <Typography variant="h5">
+                      <ToVerifyCounter
+                        needsRefresh={props.verityState.invalidateTreeCount}
                         fetch={props.verityDispatch.getTreeCount}
-                        data={props.verityState.treeCount}/>
+                        data={props.verityState.treeCount}
+                      />
                     </Typography>
                   </Grid>
-                  <Grid item>
-                    {imagePagination}
-                  </Grid>
+                  <Grid item>{imagePagination}</Grid>
                 </Grid>
               </Grid>
               <Grid
                 item
                 style={{
-                  width: '100%'
+                  width: '100%',
                 }}
               >
-                <Grid container className={classes.wrapper} spacing={1}>{treeImageItems}</Grid>
+                <Grid container className={classes.wrapper} spacing={1}>
+                  {treeImageItems}
+                </Grid>
               </Grid>
-              <Grid item container justify='flex-end' className={classes.title}>
+              <Grid item container justify="flex-end" className={classes.title}>
                 {imagePagination}
               </Grid>
             </Grid>
           </Grid>
         </Grid>
-        <SidePanel
-          onSubmit={handleSubmit}
-        />
+        <SidePanel onSubmit={handleSubmit} />
       </Grid>
       {props.verityState.isApproveAllProcessing && (
         <AppBar
-          position='fixed'
+          position="fixed"
           style={{
-            zIndex: 10000
+            zIndex: 10000,
           }}
         >
           <LinearProgress
-            color='primary'
-            variant='determinate'
+            color="primary"
+            variant="determinate"
             value={complete}
           />
         </AppBar>
@@ -511,27 +521,31 @@ const TreeImageScrubber = (props) => {
           <div></div>
         </Modal>
       )}
-      {false /* close undo */ && !props.verityState.isApproveAllProcessing && !props.verityState.isRejectAllProcessing &&
+      {false /* close undo */ &&
+        !props.verityState.isApproveAllProcessing &&
+        !props.verityState.isRejectAllProcessing &&
         props.verityState.treeImagesUndo.length > 0 && (
           <Snackbar
             open
             autoHideDuration={15000}
             ContentProps={{
               className: classes.snackbarContent,
-              'aria-describedby': 'snackbar-fab-message-id'
+              'aria-describedby': 'snackbar-fab-message-id',
             }}
             message={
-              <span id='snackbar-fab-message-id'>
-                You have {props.verityState.isBulkApproving ? ' approved ' : ' rejected '}
-                {props.verityState.treeImagesUndo.length}{' '}
-                trees
+              <span id="snackbar-fab-message-id">
+                You have{' '}
+                {props.verityState.isBulkApproving
+                  ? ' approved '
+                  : ' rejected '}
+                {props.verityState.treeImagesUndo.length} trees
               </span>
             }
-            color='primary'
+            color="primary"
             action={
               <Button
-                color='inherit'
-                size='small'
+                color="inherit"
+                size="small"
                 onClick={async () => {
                   await props.verityDispatch.undoAll();
                   log.log('finished');
@@ -555,73 +569,90 @@ const TreeImageScrubber = (props) => {
         tree={dialog.tree}
       />
     </React.Fragment>
-  )
+  );
 };
 
 function SidePanel(props) {
   const classes = useStyles(props);
-  const [switchApprove, handleSwitchApprove] = React.useState(0)
-  const [morphology, handleMorphology] = React.useState('seedling')
-  const [age, handleAge] = React.useState('new_tree')
-  const [captureApprovalTag, handleCaptureApprovalTag] = React.useState('simple_leaf')
-  const [rejectionReason, handleRejectionReason] = React.useState('not_tree')
-  const speciesRef = React.useRef(null)
+  const [switchApprove, handleSwitchApprove] = React.useState(0);
+  const [morphology, handleMorphology] = React.useState('seedling');
+  const [age, handleAge] = React.useState('new_tree');
+  const [captureApprovalTag, handleCaptureApprovalTag] = React.useState(
+    'simple_leaf'
+  );
+  const [rejectionReason, handleRejectionReason] = React.useState('not_tree');
+  const speciesRef = React.useRef(null);
 
   function handleSubmit() {
-    const approveAction = switchApprove === 0 ?
-      {
-        isApproved: true,
-        morphology,
-        age,
-        captureApprovalTag,
-      }
-      :
-      {
-        isApproved: false,
-        rejectionReason,
-      }
-    props.onSubmit(approveAction)
+    const approveAction =
+      switchApprove === 0
+        ? {
+            isApproved: true,
+            morphology,
+            age,
+            captureApprovalTag,
+          }
+        : {
+            isApproved: false,
+            rejectionReason,
+          };
+    props.onSubmit(approveAction);
   }
 
   return (
     <Drawer
-      variant='permanent'
-      anchor='right'
+      variant="permanent"
+      anchor="right"
       className={classes.sidePanel}
       classes={{
-        paper: classes.drawerPaper
+        paper: classes.drawerPaper,
       }}
       elevation={11}
     >
-      <Grid container direction={'column'} className={classes.sidePanelContainer}>
+      <Grid
+        container
+        direction={'column'}
+        className={classes.sidePanelContainer}
+      >
         <Grid>
-          <Typography variant='h5' >Tags</Typography>
+          <Typography variant="h5">Tags</Typography>
         </Grid>
         <Grid className={`${classes.bottomLine} ${classes.sidePanelItem}`}>
           <RadioGroup value={morphology} className={classes.radioGroup}>
             <FormControlLabel
-              value='seedling'
+              value="seedling"
               onClick={() => handleMorphology('seedling')}
               control={<Radio />}
-              label='Seedling' />
+              label="Seedling"
+            />
             <FormControlLabel
-              value='direct_seedling'
+              value="direct_seedling"
               control={<Radio />}
               onClick={() => handleMorphology('direct_seedling')}
-              label='Direct seeding' />
+              label="Direct seeding"
+            />
             <FormControlLabel
               onClick={() => handleMorphology('fmnr')}
-              value='fmnr' control={<Radio />} label='Pruned/tied (FMNR)' />
+              value="fmnr"
+              control={<Radio />}
+              label="Pruned/tied (FMNR)"
+            />
           </RadioGroup>
         </Grid>
         <Grid className={`${classes.bottomLine} ${classes.sidePanelItem}`}>
           <RadioGroup value={age} className={classes.radioGroup}>
             <FormControlLabel
               onClick={() => handleAge('new_tree')}
-              value='new_tree' control={<Radio />} label='New tree(s)' />
+              value="new_tree"
+              control={<Radio />}
+              label="New tree(s)"
+            />
             <FormControlLabel
               onClick={() => handleAge('over_two_years')}
-              value='over_two_years' control={<Radio />} label='> 2 years old' />
+              value="over_two_years"
+              control={<Radio />}
+              label="> 2 years old"
+            />
           </RadioGroup>
         </Grid>
         {/*
@@ -633,116 +664,158 @@ function SidePanel(props) {
         </Grid>
         */}
         <Grid>
-          <Typography variant='h6'>Species (if known)</Typography>
-          <Species
-            ref={speciesRef}
-          />
+          <Typography variant="h6">Species (if known)</Typography>
+          <Species ref={speciesRef} />
         </Grid>
         <Grid>
-          <Typography variant='h6'>Additional tags</Typography>
-          <TreeTags placeholder='Add other text tags' />
+          <Typography variant="h6">Additional tags</Typography>
+          <TreeTags placeholder="Add other text tags" />
         </Grid>
         <Grid className={`${classes.bottomLine} ${classes.sidePanelItem}`}>
           <Tabs
-            indicatorColor='primary'
-            textColor='primary'
-            variant='fullWidth'
+            indicatorColor="primary"
+            textColor="primary"
+            variant="fullWidth"
             value={switchApprove}
           >
-            <Tab label='APPROVE'
-              id='full-width-tab-0'
-              aria-controls='full-width-tabpanel-0'
+            <Tab
+              label="APPROVE"
+              id="full-width-tab-0"
+              aria-controls="full-width-tabpanel-0"
               onClick={() => handleSwitchApprove(0)}
             />
             <Tab
-              label='REJECT'
-              id='full-width-tab-0'
-              aria-controls='full-width-tabpanel-0'
+              label="REJECT"
+              id="full-width-tab-0"
+              aria-controls="full-width-tabpanel-0"
               onClick={() => handleSwitchApprove(1)}
             />
           </Tabs>
-          {switchApprove === 0 &&
-            <RadioGroup
-              value={captureApprovalTag}
-            >
+          {switchApprove === 0 && (
+            <RadioGroup value={captureApprovalTag}>
               <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('simple_leaf')}
-                value='simple_leaf' control={<Radio />} label='Simple leaf' />
+                value="simple_leaf"
+                control={<Radio />}
+                label="Simple leaf"
+              />
               <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('complex_leaf')}
-                value='complex_leaf' control={<Radio />} label='Complex leaf' />
+                value="complex_leaf"
+                control={<Radio />}
+                label="Complex leaf"
+              />
               <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('acacia_like')}
-                value='acacia_like' control={<Radio />} label='Acacia-like' />
+                value="acacia_like"
+                control={<Radio />}
+                label="Acacia-like"
+              />
               <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('conifer')}
-                value='conifer' control={<Radio />} label='Conifer' />
+                value="conifer"
+                control={<Radio />}
+                label="Conifer"
+              />
               <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('fruit')}
-                value='fruit' control={<Radio />} label='Fruit' />
+                value="fruit"
+                control={<Radio />}
+                label="Fruit"
+              />
               <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('mangrove')}
-                value='mangrove' control={<Radio />} label='Mangrove' />
+                value="mangrove"
+                control={<Radio />}
+                label="Mangrove"
+              />
               <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('palm')}
-                value='palm' control={<Radio />} label='Palm' />
+                value="palm"
+                control={<Radio />}
+                label="Palm"
+              />
               <FormControlLabel
                 onClick={() => handleCaptureApprovalTag('timber')}
-                value='timber' control={<Radio />} label='Timber' />
+                value="timber"
+                control={<Radio />}
+                label="Timber"
+              />
             </RadioGroup>
-          }
-          {switchApprove === 1 &&
-            <RadioGroup
-              value={rejectionReason}
-            >
+          )}
+          {switchApprove === 1 && (
+            <RadioGroup value={rejectionReason}>
               <FormControlLabel
                 onClick={() => handleRejectionReason('not_tree')}
-                value='not_tree' control={<Radio />} label='Not a tree' />
+                value="not_tree"
+                control={<Radio />}
+                label="Not a tree"
+              />
               <FormControlLabel
                 onClick={() => handleRejectionReason('unapproved_tree')}
-                value='unapproved_tree' control={<Radio />} label='Not an approved tree' />
+                value="unapproved_tree"
+                control={<Radio />}
+                label="Not an approved tree"
+              />
               <FormControlLabel
                 onClick={() => handleRejectionReason('blurry_image')}
-                value='blurry_image' control={<Radio />} label='Blurry photo' />
+                value="blurry_image"
+                control={<Radio />}
+                label="Blurry photo"
+              />
               <FormControlLabel
                 onClick={() => handleRejectionReason('dead')}
-                value='dead' control={<Radio />} label='Dead' />
+                value="dead"
+                control={<Radio />}
+                label="Dead"
+              />
               <FormControlLabel
                 onClick={() => handleRejectionReason('duplicate_image')}
-                value='duplicate_image' control={<Radio />} label='Duplicate photo' />
+                value="duplicate_image"
+                control={<Radio />}
+                label="Duplicate photo"
+              />
               <FormControlLabel
                 onClick={() => handleRejectionReason('flag_user')}
-                value='flag_user' control={<Radio />} label='Flag user!' />
+                value="flag_user"
+                control={<Radio />}
+                label="Flag user!"
+              />
               <FormControlLabel
                 onClick={() => handleRejectionReason('needs_contact_or_review')}
-                value='needs_contact_or_review' control={<Radio />} label='Flag tree for contact/review' />
+                value="needs_contact_or_review"
+                control={<Radio />}
+                label="Flag tree for contact/review"
+              />
             </RadioGroup>
-          }
-
+          )}
         </Grid>
         {/*Hidden until functionality is implemented. Issuer: https://github.com/Greenstand/treetracker-admin/issues/371*/}
-        {false && <Grid className={`${classes.sidePanelItem}`}>
-          <TextField placeholder='Note (optional)' ></TextField>
-        </Grid>}
+        {false && (
+          <Grid className={`${classes.sidePanelItem}`}>
+            <TextField placeholder="Note (optional)"></TextField>
+          </Grid>
+        )}
         <Grid className={`${classes.sidePanelItem}`}>
-          <Button onClick={handleSubmit} color='primary' >SUBMIT</Button>
+          <Button onClick={handleSubmit} color="primary">
+            SUBMIT
+          </Button>
         </Grid>
       </Grid>
     </Drawer>
-  )
+  );
 }
-
 
 export default connect(
   //state
-  state => ({
+  (state) => ({
     verityState: state.verity,
     speciesState: state.species,
     plantersState: state.planters,
     tagState: state.tags,
   }),
   //dispatch
-  dispatch => ({
+  (dispatch) => ({
     verityDispatch: dispatch.verity,
     speciesDispatch: dispatch.species,
     plantersDispatch: dispatch.planters,


### PR DESCRIPTION
Sorry in advance for the formatting changes!

Adding image optimization to images on /verify, including plant details dialog and /planters, including planter details dialog. Closes #454.

The OptimizedImage component assumes that the original image urls follow the format below to parse the url and create a new one using Statically's CDN service. Please let me know if that is not the case for images in production.

https://{domain}.com/{image}

For example: 

https://treetracker-dev-images.s3.eu-central-1.amazonaws.com/2020.05.15.16.18.43_37.42138089_-121.87534965_27d083f2-e367-4ff3-b78b-06080b8b6b67_IMG_20200511_150539_5951525636141225822.jpg