### PR TITLE
fix: audit data remove req host:port matching

### DIFF
--- a/server/src/js/Audit.js
+++ b/server/src/js/Audit.js
@@ -87,7 +87,7 @@ class Audit {
     //assert(req.headers.host);
     //assert(req.headers['user-agent']);
     const host =
-      req.headers['x-real-ip'] || req.headers.host.match(/(.*):(.*)/)[1];
+      req.headers['x-real-ip'];
     const userAgent = req.headers['user-agent'];
     let operation;
     let operator;


### PR DESCRIPTION
Remove the regex matching pattern that expects host:port format in audit.js file. This causes error  on the admin panel when running  it on kubernetes cluster.