### PR TITLE
fix: don't look for host ip from request headers while auditing

### DIFF
--- a/src/js/Audit.js
+++ b/src/js/Audit.js
@@ -3,7 +3,7 @@
 /*
  * To record operation on the system
  */
-import {Pool} from 'pg';
+import { Pool } from 'pg';
 // import log from 'loglevel';
 // import {strict as assert} from 'assert';
 import getDatasource from '../datasources/config';
@@ -32,7 +32,7 @@ export const auditMiddleware = (request, response, next) => {
         const token = request.headers.authorization || '';
         if (token) {
           const user = jwt.verify(token, jwtSecret);
-          request.user = user
+          request.user = user;
         }
 
         if (/2\d\d/.test(response.statusCode)) {
@@ -78,7 +78,7 @@ export const auditMiddleware = (request, response, next) => {
 
 class Audit {
   constructor() {
-    this.pool = new Pool({connectionString: getDatasource().url});
+    this.pool = new Pool({ connectionString: getDatasource().url });
   }
 
   async did(req, res) {
@@ -86,8 +86,7 @@ class Audit {
     //assert(req.headers);
     //assert(req.headers.host);
     //assert(req.headers['user-agent']);
-    const host =
-      req.headers['x-real-ip'] || req.headers.host.match(/(.*):(.*)/)[1];
+    const host = req.headers['x-real-ip'];
     const userAgent = req.headers['user-agent'];
     let operation;
     let operator;
@@ -99,12 +98,14 @@ class Audit {
       //assert(res.myData);
       //assert(!isNaN(res.myData.user.id), res.myData.user.id);
       operator = res.myData.user.id; // change to operator = req.user.id
-    } else if (/(?:.*\/api\/trees\/\d+|.*\/api\/organization\/\d+\/trees\/\d+)/.test(url)) {
+    } else if (
+      /(?:.*\/api\/trees\/\d+|.*\/api\/organization\/\d+\/trees\/\d+)/.test(url)
+    ) {
       console.info('tree event');
       //assert(req.method, req.method);
       //assert(req.user);
       //assert(req.user.id);
-      operator = req.user.id
+      operator = req.user.id;
       if (req.method.match(/patch/i)) {
         console.info('verify event');
         //assert(req.body.id, req.body.id);

--- a/src/js/Audit.test.js
+++ b/src/js/Audit.test.js
@@ -3,7 +3,7 @@
 import request from 'supertest';
 import express from 'express';
 
-import {Pool} from 'pg';
+import { Pool } from 'pg';
 jest.mock('pg');
 
 const query = jest.fn();
@@ -11,7 +11,7 @@ Pool.mockImplementation(() => ({
   query,
 }));
 
-import {auditMiddleware} from './Audit';
+import { auditMiddleware } from './Audit';
 
 describe('Audit', () => {
   let app;
@@ -33,8 +33,8 @@ describe('Audit', () => {
       //mock to inject user in middleware
       req.user = {
         id: 555,
-        name: 'admin'
-      }
+        name: 'admin',
+      };
       console.log('verify success');
       res.status(201).send({});
     });
@@ -55,7 +55,7 @@ describe('Audit', () => {
       //
       expect(query).toHaveBeenCalledWith(
         expect.stringMatching(
-          /insert\s+into.*audit.*admin_user_id.*555.*(127.0.0.1).*(node-superagent).*login.*/i,
+          /insert\s+into.*audit.*admin_user_id.*555.*(node-superagent).*login.*/i,
         ),
       );
     });


### PR DESCRIPTION
Remove the code that looks for host in the request headers in audit.js. Corresponding test has been changed as well.