### PR TITLE
fix: organization and tree tag filters 

### DIFF
--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -2,12 +2,17 @@ import {
   DefaultCrudRepository,
   repository,
   HasManyRepositoryFactory,
+  Filter,
+  Options,
+  Where,
+  Count,
 } from '@loopback/repository';
 import { Trees, TreesRelations, TreeTag } from '../models';
 import { TreetrackerDataSource } from '../datasources';
 import { inject, Getter } from '@loopback/core';
 import { TreeTagRepository } from './treeTag.repository';
 import expect from 'expect-runtime';
+import { buildFilterQuery } from '../js/buildFilterQuery.js';
 
 export class TreesRepository extends DefaultCrudRepository<
   Trees,
@@ -85,6 +90,112 @@ export class TreesRepository extends DefaultCrudRepository<
           { planterId: { inq: planterIds } },
         ],
       };
+    }
+  }
+
+  async applyOrganizationWhereClause(
+    where: Object | undefined,
+    organizationId: number | undefined,
+  ): Promise<Object | undefined> {
+    if (!where || organizationId === undefined) {
+      return Promise.resolve(where);
+    }
+    const organizationWhereClause = await this.getOrganizationWhereClause(
+      organizationId,
+    );
+    return {
+      and: [where, organizationWhereClause],
+    };
+  }
+
+  // In order to filter by tagId (treeTags relation), we need to bypass the LoopBack find()
+  async findWithTagId(
+    filter?: Filter<Trees>,
+    tagId?: string,
+    options?: Options,
+  ): Promise<(Trees & TreesRelations)[]> {
+    if (!filter || tagId === undefined) {
+      return await this.find(filter, options);
+    }
+
+    try {
+      if (this.dataSource.connector) {
+        // If included, replace 'id' with 'tree_id as id' to avoid ambiguity
+        const columnNames = this.dataSource.connector
+          .buildColumnNames('Trees', filter)
+          .replace('"id"', 'trees.id as "id"');
+
+        const isTagNull = tagId === null;
+
+        const sql = `SELECT ${columnNames} from trees ${
+          isTagNull
+            ? 'LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id ORDER BY "time_created" DESC'
+            : 'JOIN tree_tag ON trees.id=tree_tag.tree_id'
+        } WHERE tree_tag.tag_id ${isTagNull ? 'IS NULL' : `=${tagId}`}`;
+
+        const params = {
+          filter: filter?.where,
+          repo: this,
+          model: 'Trees',
+        };
+
+        const query = buildFilterQuery(sql, params);
+
+        return <Promise<Trees[]>>await this.execute(
+          query.sql,
+          query.params,
+          options,
+        ).then((data) => {
+          return data.map((obj) =>
+            this.dataSource.connector?.fromRow('Trees', obj),
+          );
+        });
+      } else {
+        throw 'Connector not defined';
+      }
+    } catch (e) {
+      console.log(e);
+      return await this.find(filter, options);
+    }
+  }
+
+  // In order to filter by tagId (treeTags relation), we need to bypass the LoopBack count()
+  async countWithTagId(
+    where?: Where<Trees>,
+    tagId?: string,
+    options?: Options,
+  ): Promise<Count> {
+    if (!where || tagId === undefined) {
+      return await this.count(where, options);
+    }
+
+    try {
+      const isTagNull = tagId === null;
+
+      const sql = `SELECT COUNT(*) FROM trees ${
+        isTagNull ? 'LEFT JOIN' : 'JOIN'
+      } tree_tag ON trees.id=tree_tag.tree_id WHERE tree_tag.tag_id ${
+        isTagNull ? 'IS NULL' : `=${tagId}`
+      }`;
+
+      const params = {
+        filter: where,
+        repo: this,
+        model: 'Trees',
+      };
+
+      const query = buildFilterQuery(sql, params);
+
+      return <Promise<Count>>await this.execute(
+        query.sql,
+        query.params,
+        options,
+      ).then((res) => {
+        return (res && res[0]) || { count: 0 };
+      });
+    } catch (e) {
+      console.log(e);
+      return await this.count(where, options);
     }
   }
 }


### PR DESCRIPTION
Resolves #542 

In order to reduce duplication and minimise the risk of divergence, all non-trivial `trees` filter logic has been consolidated and moved to `trees.repository.ts`.
This means that the same LoopBack queries are used by the normal and organizational `trees` API endpoints, and `find` and `count` calls will always return the same set of items.

As well as the organization bug identified in the issue referenced, the tree tag filter was broken when used in conjunction with other filters.
The `count` would be different to the number of records returned by the equivalent `find`.