### PR TITLE
fix: apply pagination to Verify tree query when filtering by tag

### DIFF
--- a/src/controllers/planterRegistration.controller.ts
+++ b/src/controllers/planterRegistration.controller.ts
@@ -36,9 +36,9 @@ export class PlanterRegistrationController {
     ) AS region ON ST_DWithin(region.geom, planter_registrations.geom, 0.01)`;
 
     const params = {
-      filter: filter?.where,
+      filter,
       repo: this.planterRepository,
-      model: 'PlanterRegistration',
+      modelName: 'PlanterRegistration',
     };
 
     const query = buildFilterQuery(sql, params);

--- a/src/js/buildFilterQuery.js
+++ b/src/js/buildFilterQuery.js
@@ -5,6 +5,9 @@ export function getConnector(repo) {
   return repo?.dataSource?.connector;
 }
 
+// This method is based on LoopBack's SQLConnector.prototype.buildSelect(),
+// but caters for JOINS and existing WHERE in the SELECT statement passed in.
+// (See node_modules/loopback_connector/lib/sql.js)
 export function buildFilterQuery(selectStmt, params) {
   let query = new ParameterizedSQL(selectStmt);
 

--- a/src/js/buildFilterQuery.js
+++ b/src/js/buildFilterQuery.js
@@ -5,28 +5,42 @@ export function getConnector(repo) {
   return repo?.dataSource?.connector;
 }
 
-export function buildFilterQuery(sql, params) {
-  let query = new ParameterizedSQL(sql);
+export function buildFilterQuery(selectStmt, params) {
+  let query = new ParameterizedSQL(selectStmt);
 
-  if (params.filter) {
-    const connector = getConnector(params.repo);
-    if (connector) {
-      const model = connector._models[params.model].model;
+  if (!params) {
+    return query;
+  }
+
+  const { modelName, repo, filter } = params;
+  const connector = getConnector(repo);
+
+  if (filter && modelName && connector) {
+    if (filter.where) {
+      const model = connector.getModelDefinition(modelName)?.model;
 
       if (model) {
-        let safeWhere = model._sanitizeQuery(params.filter);
+        let safeWhere = model._sanitizeQuery(filter.where);
         safeWhere = model._coerce(safeWhere);
 
-        const whereObjClause = connector._buildWhere(params.model, safeWhere);
+        const whereObjClause = connector._buildWhere(modelName, safeWhere);
 
         if (whereObjClause.sql) {
-          const hasWhere = /WHERE(?![^(]*\))/i.test(sql);
+          const hasWhere = /WHERE(?![^(]*\))/i.test(selectStmt);
           query.sql += ` ${hasWhere ? 'AND' : 'WHERE'} ${whereObjClause.sql}`;
           query.params = whereObjClause.params;
         }
 
         query = connector.parameterize(query);
       }
+    }
+
+    if (filter.order) {
+      query.merge(connector.buildOrderBy(modelName, filter.order));
+    }
+
+    if (filter.limit || filter.skip || filter.offset) {
+      query = connector.applyPagination(modelName, query, filter);
     }
   }
 

--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -12,8 +12,7 @@ import { TreetrackerDataSource } from '../datasources';
 import { inject, Getter } from '@loopback/core';
 import { TreeTagRepository } from './treeTag.repository';
 import expect from 'expect-runtime';
-import { buildFilterQuery } from '../js/buildFilterQuery.js';
-
+import { buildFilterQuery } from '../js/buildFilterQuery';
 export class TreesRepository extends DefaultCrudRepository<
   Trees,
   typeof Trees.prototype.id,
@@ -132,17 +131,17 @@ export class TreesRepository extends DefaultCrudRepository<
           .buildColumnNames('Trees', filter)
           .replace('"id"', 'trees.id as "id"');
 
-        const sql = `SELECT ${columnNames} from trees ${this.getTreeTagJoinClause(
+        const selectStmt = `SELECT ${columnNames} from trees ${this.getTreeTagJoinClause(
           tagId,
         )}`;
 
         const params = {
-          filter: filter?.where,
+          filter,
           repo: this,
-          model: 'Trees',
+          modelName: 'Trees',
         };
 
-        const query = buildFilterQuery(sql, params);
+        const query = buildFilterQuery(selectStmt, params);
 
         return <Promise<Trees[]>>await this.execute(
           query.sql,
@@ -173,17 +172,17 @@ export class TreesRepository extends DefaultCrudRepository<
     }
 
     try {
-      const sql = `SELECT COUNT(*) FROM trees ${this.getTreeTagJoinClause(
+      const selectStmt = `SELECT COUNT(*) FROM trees ${this.getTreeTagJoinClause(
         tagId,
       )}`;
 
       const params = {
-        filter: where,
+        filter: { where },
         repo: this,
-        model: 'Trees',
+        modelName: 'Trees',
       };
 
-      const query = buildFilterQuery(sql, params);
+      const query = buildFilterQuery(selectStmt, params);
 
       return <Promise<Count>>await this.execute(
         query.sql,

--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -13,6 +13,7 @@ import { inject, Getter } from '@loopback/core';
 import { TreeTagRepository } from './treeTag.repository';
 import expect from 'expect-runtime';
 import { buildFilterQuery } from '../js/buildFilterQuery';
+
 export class TreesRepository extends DefaultCrudRepository<
   Trees,
   typeof Trees.prototype.id,


### PR DESCRIPTION
Resolves #554 

The custom `buildFilterQuery()` now caters for `order`, `limit`, `skip` or `offset` in the LoopBack filter parameters.
This method is called when we need to extend LoopBack's reach to do joins.

Logic from `SQLConnector.prototype.buildSelect()` in `node_modules/loopback_connector/lib/sql.js` is duplicated to ensure consistency.

The previous query sent to Postgres when filtering by tag ID was:
```sql
SELECT trees.id as "id","time_created","time_updated","planter_id","image_url","lat","lon","active","planter_identifier","device_identifier","approved" from trees LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id ISNULL) AND "approved"=false AND "active"=true
```
It is now (on page 2 of results):
```sql
SELECT trees.id as "id","time_created","time_updated","planter_id","image_url","lat","lon","active","planter_identifier","device_identifier","approved" from trees LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id ISNULL) AND "approved"=false AND "active"=true ORDER BY "id" desc LIMIT 12 OFFSET 12
```