### PR TITLE
fix: enable DELETE on API deployment

### DIFF
--- a/deployment/overlays/development/treetracker-admin-api-mapping.yaml
+++ b/deployment/overlays/development/treetracker-admin-api-mapping.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   cors:
     origins: '*'
-    methods: GET, POST, PATCH, PUT, OPTIONS
+    methods: GET, POST, PATCH, PUT, OPTIONS, DELETE
     headers:
       - Content-Type
       - Authorization

--- a/deployment/overlays/production/treetracker-admin-api-mapping.yaml
+++ b/deployment/overlays/production/treetracker-admin-api-mapping.yaml
@@ -7,7 +7,7 @@ spec:
     origins:
       - https://admin.treetracker.org
       - https://d2swy6guhjfbkg.cloudfront.net
-    methods: GET, POST, PATCH, PUT, OPTIONS
+    methods: GET, POST, PATCH, PUT, OPTIONS, DELETE
     headers:
       - Content-Type
       - Authorization

--- a/deployment/overlays/test/treetracker-admin-api-mapping.yaml
+++ b/deployment/overlays/test/treetracker-admin-api-mapping.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   cors:
     origins:
-      - https://test.admin.treetracker.org
+      - https://test-admin.treetracker.org
       - https://d2s7z62c7yrbt1.cloudfront.net
-    methods: GET, POST, PATCH, PUT, OPTIONS
+    methods: GET, POST, PATCH, PUT, OPTIONS, DELETE
     headers:
       - Content-Type
       - Authorization


### PR DESCRIPTION
Resolves #553

The API supports the `DELETE` method and translates it to setting `active=false` on the matching record.
This is now reflected in the deployment configuration.