### PR TITLE
fix: organization user unauthorized error for verify filter

### DIFF
--- a/src/controllers/organization.controller.ts
+++ b/src/controllers/organization.controller.ts
@@ -51,7 +51,6 @@ export class OrganizationController {
     @param.query.object('filter', getFilterSchemaFor(Organization))
     filter?: Filter<Organization>,
   ): Promise<Organization[]> {
-    console.log(filter, filter ? filter.where : null);
     return await this.organizationRepository.find(filter);
   }
 

--- a/src/controllers/organization.controller.ts
+++ b/src/controllers/organization.controller.ts
@@ -54,6 +54,35 @@ export class OrganizationController {
     return await this.organizationRepository.find(filter);
   }
 
+  @get('/organization/{organizationId}/organizations', {
+    responses: {
+      '200': {
+        description: 'Array of Organization model instances by Org',
+        content: {
+          'application/json': {
+            schema: { type: 'array', items: { 'x-ts-type': Organization } },
+          },
+        },
+      },
+    },
+  })
+  async findByParentOrg(
+    @param.path.number('organizationId') organizationId: Number,
+    @param.query.object('filter', getFilterSchemaFor(Organization))
+    filter?: Filter<Organization>,
+  ): Promise<Organization[]> {
+    if (filter?.where) {
+      filter.where = await this.organizationRepository.applyOrganizationWhereClause(
+        filter.where,
+        organizationId.valueOf(),
+      );
+    }
+    // console.log('/organizations ?filter --> ', organizationId, filter, filter?.where);
+    const result = await this.organizationRepository.find(filter);
+    // console.log('/organizations res --> ', result);
+    return result;
+  }
+
   @get('/organizations/{id}', {
     responses: {
       '200': {

--- a/src/controllers/planterOrganization.controller.ts
+++ b/src/controllers/planterOrganization.controller.ts
@@ -128,5 +128,13 @@ export class PlanterOrganizationController {
         'Organizational user has no permission to do this operation',
       );
     }
+    // const result = await this.planterRepository.findById(id);
+    // const entityIds = await this.treesRepository.getEntityIdsByOrganizationId(organizationId);
+    // if (!entityIds.includes(result?.organizationId?.valueOf() || -1)) {
+    //   throw new HttpErrors.Unauthorized(
+    //     'Organizational user has no permission to do this operation',
+    //   );
+    // }
+    // await this.planterRepository.updateById(id, planter);
   }
 }

--- a/src/controllers/planterOrganization.controller.ts
+++ b/src/controllers/planterOrganization.controller.ts
@@ -108,7 +108,7 @@ export class PlanterOrganizationController {
         'Organizational user has no permission to do this operation',
       );
     }
-    return await this.planterRepository.findById(id);
+    return result;
   }
 
   @patch('/organization/{organizationId}/planter/{id}', {
@@ -123,18 +123,10 @@ export class PlanterOrganizationController {
     @param.path.number('id') id: Number,
     @requestBody() planter: Planter,
   ): Promise<void> {
-    throw new HttpErrors.Unauthorized(
-      'Organizational user has no permission to do this operation',
-    );
-    const result = await this.planterRepository.findById(id);
-    const entityIds = await this.treesRepository.getEntityIdsByOrganizationId(
-      organizationId.valueOf(),
-    );
-    if (!entityIds.includes(result?.organizationId?.valueOf() || -1)) {
+    if (organizationId) {
       throw new HttpErrors.Unauthorized(
         'Organizational user has no permission to do this operation',
       );
     }
-    await this.planterRepository.updateById(id, planter);
   }
 }

--- a/src/js/auth.test.js
+++ b/src/js/auth.test.js
@@ -112,7 +112,7 @@ describe('auth', () => {
       );
       expect(hasPermission([{ name: 'test' }], null, ['test'], 1)).toBe(true);
       expect(hasPermission([{ name: 'test' }], { id: 1 }, ['test'], null)).toBe(
-        true,
+        false,
       );
       expect(hasPermission([{ name: 'test' }], null, ['other'], null)).toBe(
         false,

--- a/src/js/auth.test.js
+++ b/src/js/auth.test.js
@@ -112,7 +112,7 @@ describe('auth', () => {
       );
       expect(hasPermission([{ name: 'test' }], null, ['test'], 1)).toBe(true);
       expect(hasPermission([{ name: 'test' }], { id: 1 }, ['test'], null)).toBe(
-        false,
+        true,
       );
       expect(hasPermission([{ name: 'test' }], null, ['other'], null)).toBe(
         false,

--- a/src/repositories/organization.repository.ts
+++ b/src/repositories/organization.repository.ts
@@ -2,6 +2,7 @@ import { DefaultCrudRepository } from '@loopback/repository';
 import { Organization, OrganizationRelations } from '../models';
 import { TreetrackerDataSource } from '../datasources';
 import { inject } from '@loopback/core';
+import expect from 'expect-runtime';
 
 export class OrganizationRepository extends DefaultCrudRepository<
   Organization,
@@ -12,5 +13,30 @@ export class OrganizationRepository extends DefaultCrudRepository<
     @inject('datasources.treetracker') dataSource: TreetrackerDataSource,
   ) {
     super(Organization, dataSource);
+  }
+
+  async getEntityIdsByOrganizationId(
+    organizationId: number,
+  ): Promise<Array<number>> {
+    expect(organizationId).number();
+    expect(this).property('execute').defined();
+    const result = await this.execute(
+      `select * from getEntityRelationshipChildren(${organizationId})`,
+      [],
+    );
+    return result.map((e) => e.entity_id);
+  }
+
+  async applyOrganizationWhereClause(
+    where: Object | undefined,
+    organizationId: number | undefined,
+  ): Promise<Object | undefined> {
+    if (!where || organizationId === undefined) {
+      return Promise.resolve(where);
+    }
+    const entityIds = await this.getEntityIdsByOrganizationId(organizationId);
+    return {
+      and: [where, { id: { inq: entityIds } }],
+    };
   }
 }


### PR DESCRIPTION
auth.js
        - add a new path to check for organization permissions
        - adjust logic to allow both admin and org accounts to get permissions based on if a requestedOrgId is in the url
        
        https://github.com/Greenstand/treetracker-admin-client/issues/70