### PR TITLE
chore: move the rabbitmq connection inside try/catch block

### DIFF
--- a/src/messaging/RabbitMQMessaging.js
+++ b/src/messaging/RabbitMQMessaging.js
@@ -3,8 +3,8 @@ import { BrokerAsPromised as Broker } from 'rascal';
 import { config } from './config';
 
 const publishMessage = async (payload, resultHandler) => {
-  const broker = await Broker.create(config);
   try {
+    const broker = await Broker.create(config);
     const publication = await broker.publish('admin-verification', payload);
     publication.on('success', resultHandler).on('error', (err, messageId) => {
       console.error(`Error with id ${messageId} ${err.message}`);


### PR DESCRIPTION
This is a quick fix to capture any error that might be occuring when connecting to rabbitmq service by moving the connection within a try/catch block.

I am taking the liberty to merge this code to test this out to see if I get any errors when publishing messages.