### PR TITLE
fix: include capture count in species results

### DIFF
--- a/src/controllers/species.controller.ts
+++ b/src/controllers/species.controller.ts
@@ -66,7 +66,8 @@ export class SpeciesController {
     filter = { ...filter, where: { ...filter?.where, active: true } };
 
     const captureCountStmt =
-      'SELECT species_id,COUNT(species_id) as count FROM trees WHERE species_id NOTNULL GROUP BY species_id';
+      `SELECT species_id,COUNT(species_id) as count FROM trees ` +
+      `WHERE species_id NOTNULL AND active=true GROUP BY species_id`;
     // TODO: combine both queries in one query to minimise overhead
     const [speciesList, captureCounts] = await Promise.all([
       this.speciesRepository.find(filter),


### PR DESCRIPTION
Resolves #573

This PR merges the species capture counts directly into the results of the standard species find query.

Unfortunately, LoopBack makes it quite fiddly to arbitrarily extend objects in API responses, so I've returned `Promise<any[]>` for simplicity.
I'm open to suggestions for a better solution.

Ideally, we'd do the species find and get the capture counts all in one SQL query, but LoopBack makes the former a little opaque.
That said, performing two separate queries and merging manually shouldn't add significant overhead.

I'll update the corresponding query in the client to not make separate `api/trees/count` queries (under Greenstand/treetracker-admin-client#115).