### PR TITLE
fix: planter filter to allow filtering parent orgs by name and all orgs by id

### DIFF
--- a/src/controllers/planter.controller.ts
+++ b/src/controllers/planter.controller.ts
@@ -21,7 +21,6 @@ import { TreesFilter } from './trees.controller';
 import { PlanterRepository, TreesRepository } from '../repositories';
 
 // Extend the LoopBack filter types for the Planter model to include organizationId
-// This is a workaround for the lack of proper join support in LoopBack
 type PlanterWhere = (Where<Planter> & { organizationId?: number }) | undefined;
 export type PlanterFilter = Filter<Planter> & { where: PlanterWhere };
 

--- a/src/controllers/trees.controller.ts
+++ b/src/controllers/trees.controller.ts
@@ -60,6 +60,8 @@ export class TreesController {
       );
     }
 
+    console.log('get /trees where --> ', where);
+
     return await this.treesRepository.countWithTagId(
       where as Where<Trees>,
       tagId,
@@ -82,8 +84,6 @@ export class TreesController {
     @param.query.object('filter', getFilterSchemaFor(Trees))
     filter?: TreesFilter,
   ): Promise<Trees[]> {
-    console.log('get /trees filter --> ', filter ? filter.where : null);
-
     const tagId = filter?.where?.tagId;
 
     // Replace organizationId with full entity tree and planter
@@ -95,6 +95,7 @@ export class TreesController {
       );
     }
 
+    console.log('get /trees filter --> ', filter);
     // In order to filter by tagId (treeTags relation), we need to bypass the LoopBack find()
     return await this.treesRepository.findWithTagId(filter, tagId);
   }

--- a/src/controllers/trees.controller.ts
+++ b/src/controllers/trees.controller.ts
@@ -60,7 +60,7 @@ export class TreesController {
       );
     }
 
-    console.log('get /trees where --> ', where);
+    // console.log('get /trees/count where --> ', where);
 
     return await this.treesRepository.countWithTagId(
       where as Where<Trees>,
@@ -95,7 +95,7 @@ export class TreesController {
       );
     }
 
-    console.log('get /trees filter --> ', filter);
+    // console.log('get /trees filter --> ', filter?.where);
     // In order to filter by tagId (treeTags relation), we need to bypass the LoopBack find()
     return await this.treesRepository.findWithTagId(filter, tagId);
   }

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -357,6 +357,7 @@ router.get('/admin_users/', async (req, res) => {
 });
 
 router.post('/validate/', async (req, res) => {
+  console.log('validate');
   try {
     const { password } = req.body;
     const token = req.headers.authorization;
@@ -473,6 +474,7 @@ router.post('/init', async (req, res) => {
 });
 
 const isAuth = async (req, res, next) => {
+  console.log('isAuth...');
   //white list
   const url = req.originalUrl;
   if (url.match(/\/auth\/(login|test|init|validate)/)) {
@@ -484,11 +486,12 @@ const isAuth = async (req, res, next) => {
     const token = req.headers.authorization;
     const decodedToken = jwt.verify(token, jwtSecret);
     const userSession = decodedToken;
-    //inject the user extract from token to request object
     req.user = userSession;
 
+    // console.log('userSession', userSession);
+    console.log('url', url);
+
     // VALIDATE USER DATA
-    // const roles = userSession.role;
     expect(userSession.policy).toBeInstanceOf(Object);
     const policies = userSession.policy.policies;
     expect(policies).toBeInstanceOf(Array);
@@ -503,6 +506,7 @@ const isAuth = async (req, res, next) => {
     if (url.match(/\/auth\/check_session/)) {
       const user_id = req.query.id;
       const result = await helper.getActiveAdminUser(userSession.userName);
+      console.log('check_session user_id', user_id);
 
       if (result.rows.length) {
         const update_userSession = utils.convertCamel(result.rows[0]);

--- a/src/repositories/planter.repository.ts
+++ b/src/repositories/planter.repository.ts
@@ -1,7 +1,14 @@
-import { DefaultCrudRepository } from '@loopback/repository';
+import {
+  DefaultCrudRepository,
+  Filter,
+  Where,
+  Count,
+} from '@loopback/repository';
 import { Planter, PlanterRelations } from '../models';
 import { TreetrackerDataSource } from '../datasources';
 import { inject } from '@loopback/core';
+import expect from 'expect-runtime';
+import { buildFilterQuery } from '../js/buildFilterQuery';
 
 export class PlanterRepository extends DefaultCrudRepository<
   Planter,
@@ -12,5 +19,153 @@ export class PlanterRepository extends DefaultCrudRepository<
     @inject('datasources.treetracker') dataSource: TreetrackerDataSource,
   ) {
     super(Planter, dataSource);
+  }
+
+  async getEntityIdsByOrganizationId(
+    organizationId: number,
+  ): Promise<Array<number>> {
+    expect(organizationId).number();
+    expect(this).property('execute').defined();
+    const result = await this.execute(
+      `select * from getEntityRelationshipChildren(${organizationId})`,
+      [],
+    );
+    return result.map((e) => e.entity_id);
+  }
+
+  async getPlanterIdsByOrganizationId(
+    organizationId: number,
+  ): Promise<Array<number>> {
+    expect(organizationId).number();
+    const result = await this.execute(
+      `select * from planter where organization_id in (select entity_id from getEntityRelationshipChildren(${organizationId}))`,
+      [],
+    );
+    expect(result).match([{ id: expect.any(Number) }]);
+    return result.map((e) => e.id);
+  }
+
+  async getNonOrganizationPlanterIds(): Promise<Array<number>> {
+    const result = await this.execute(
+      `select * from planter where organization_id isnull`,
+      [],
+    );
+    expect(result).match([{ id: expect.any(Number) }]);
+    return result.map((e) => e.id);
+  }
+
+  async getOrganizationWhereClause(organizationId: number): Promise<Object> {
+    if (organizationId === null) {
+      const planterIds = await this.getNonOrganizationPlanterIds();
+      return {
+        and: [
+          { plantingOrganizationId: null },
+          { planterId: { inq: planterIds } },
+        ],
+      };
+    } else {
+      const planterIds = await this.getPlanterIdsByOrganizationId(
+        organizationId,
+      );
+      const entityIds = await this.getEntityIdsByOrganizationId(organizationId);
+
+      // console.log(
+      //   'getOrganizationWhereClause: planterIds, entityIds --',
+      //   planterIds,
+      //   entityIds,
+      // );
+      return {
+        or: [
+          { organizationId: { inq: entityIds } },
+          { id: { inq: planterIds } },
+        ],
+      };
+    }
+  }
+
+  async applyOrganizationWhereClause(
+    where: Object | undefined,
+    organizationId: number | undefined,
+  ): Promise<Object | undefined> {
+    if (!where || organizationId === undefined) {
+      return Promise.resolve(where);
+    }
+    const organizationWhereClause = await this.getOrganizationWhereClause(
+      organizationId,
+    );
+    return {
+      and: [where, organizationWhereClause],
+    };
+  }
+
+  // loopback .find() wasn't applying the org filters
+  async findWithOrg(
+    filter?: Filter<Planter>,
+  ): Promise<(Planter & PlanterRelations)[]> {
+    console.log('findWithOrg ---', filter?.where);
+
+    if (!filter) {
+      return await this.find(filter);
+    }
+
+    try {
+      if (this.dataSource.connector) {
+        const columnNames = this.dataSource.connector.buildColumnNames(
+          'Planter',
+          filter,
+        );
+
+        const selectStmt = `SELECT ${columnNames} FROM planter `;
+
+        const params = {
+          filter,
+          repo: this,
+          modelName: 'Planter',
+        };
+
+        const query = buildFilterQuery(selectStmt, params);
+
+        console.log('final query', query);
+
+        return <Promise<Planter[]>>await this.execute(query.sql, query.params);
+      } else {
+        throw 'Connector not defined';
+      }
+    } catch (e) {
+      console.log(e);
+      return await this.find(filter);
+    }
+  }
+
+  async countWithOrg(where?: Where<Planter>): Promise<Count> {
+    // console.log('countWithOrg ---', where);
+
+    if (!where) {
+      return await this.count(where);
+    }
+
+    try {
+      const selectStmt = `SELECT COUNT(*) FROM planter `;
+
+      const params = {
+        filter: { where },
+        repo: this,
+        modelName: 'Planter',
+      };
+
+      const query = buildFilterQuery(selectStmt, params);
+
+      // console.log('final count query', query);
+
+      return <Promise<Count>>await this.execute(query.sql, query.params).then(
+        (res) => {
+          // responds with count value as a string
+          return (res && res[0]) || { count: 0 };
+        },
+      );
+    } catch (e) {
+      console.log(e);
+      return await this.count(where);
+    }
   }
 }

--- a/src/repositories/planter.repository.ts
+++ b/src/repositories/planter.repository.ts
@@ -69,11 +69,6 @@ export class PlanterRepository extends DefaultCrudRepository<
       );
       const entityIds = await this.getEntityIdsByOrganizationId(organizationId);
 
-      // console.log(
-      //   'getOrganizationWhereClause: planterIds, entityIds --',
-      //   planterIds,
-      //   entityIds,
-      // );
       return {
         or: [
           { organizationId: { inq: entityIds } },
@@ -102,8 +97,6 @@ export class PlanterRepository extends DefaultCrudRepository<
   async findWithOrg(
     filter?: Filter<Planter>,
   ): Promise<(Planter & PlanterRelations)[]> {
-    console.log('findWithOrg ---', filter?.where);
-
     if (!filter) {
       return await this.find(filter);
     }
@@ -125,8 +118,6 @@ export class PlanterRepository extends DefaultCrudRepository<
 
         const query = buildFilterQuery(selectStmt, params);
 
-        console.log('final query', query);
-
         return <Promise<Planter[]>>await this.execute(query.sql, query.params);
       } else {
         throw 'Connector not defined';
@@ -138,8 +129,6 @@ export class PlanterRepository extends DefaultCrudRepository<
   }
 
   async countWithOrg(where?: Where<Planter>): Promise<Count> {
-    // console.log('countWithOrg ---', where);
-
     if (!where) {
       return await this.count(where);
     }
@@ -154,8 +143,6 @@ export class PlanterRepository extends DefaultCrudRepository<
       };
 
       const query = buildFilterQuery(selectStmt, params);
-
-      // console.log('final count query', query);
 
       return <Promise<Count>>await this.execute(query.sql, query.params).then(
         (res) => {

--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -71,6 +71,7 @@ export class TreesRepository extends DefaultCrudRepository<
   }
 
   async getOrganizationWhereClause(organizationId: number): Promise<Object> {
+    // console.log('getOrganizationWhereClause orgId ---', organizationId);
     if (organizationId === null) {
       const planterIds = await this.getNonOrganizationPlanterIds();
       return {
@@ -85,11 +86,12 @@ export class TreesRepository extends DefaultCrudRepository<
       );
       const entityIds = await this.getEntityIdsByOrganizationId(organizationId);
 
-      console.log(
-        'getOrganizationWhereClause: planterIds, entityIds --',
-        planterIds,
-        entityIds,
-      );
+      // console.log(
+      //   'getOrganizationWhereClause: planterIds, entityIds --',
+      //   planterIds,
+      //   entityIds,
+      // );
+
       return {
         or: [
           { plantingOrganizationId: { inq: entityIds } },
@@ -127,7 +129,6 @@ export class TreesRepository extends DefaultCrudRepository<
     tagId?: string,
     options?: Options,
   ): Promise<(Trees & TreesRelations)[]> {
-    console.log('trees filter ********', filter);
     if (!filter || tagId === undefined) {
       return await this.find(filter, options);
     }
@@ -150,8 +151,6 @@ export class TreesRepository extends DefaultCrudRepository<
         };
 
         const query = buildFilterQuery(selectStmt, params);
-
-        console.log('trees build filter query  ********', query);
 
         return <Promise<Trees[]>>await this.execute(
           query.sql,

--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -84,6 +84,12 @@ export class TreesRepository extends DefaultCrudRepository<
         organizationId,
       );
       const entityIds = await this.getEntityIdsByOrganizationId(organizationId);
+
+      console.log(
+        'getOrganizationWhereClause: planterIds, entityIds --',
+        planterIds,
+        entityIds,
+      );
       return {
         or: [
           { plantingOrganizationId: { inq: entityIds } },
@@ -121,6 +127,7 @@ export class TreesRepository extends DefaultCrudRepository<
     tagId?: string,
     options?: Options,
   ): Promise<(Trees & TreesRelations)[]> {
+    console.log('trees filter ********', filter);
     if (!filter || tagId === undefined) {
       return await this.find(filter, options);
     }
@@ -143,6 +150,8 @@ export class TreesRepository extends DefaultCrudRepository<
         };
 
         const query = buildFilterQuery(selectStmt, params);
+
+        console.log('trees build filter query  ********', query);
 
         return <Promise<Trees[]>>await this.execute(
           query.sql,


### PR DESCRIPTION
- updated /planter and /count endpoints to get both parent and child org entityIds and and planter ids for the query
- updated /organization/{orgid}/planter, .../trees, and .../count endpoints to check if an org filter was requested, compare it to the org account id, and override the value in the query if it's a sub-org
- updated /organizations to get all the parent orgs for admin and all the sub-orgs for an org account
