### PR TITLE
fix: convert planter attributes to camel case

### DIFF
--- a/src/repositories/planter.repository.ts
+++ b/src/repositories/planter.repository.ts
@@ -9,6 +9,7 @@ import { TreetrackerDataSource } from '../datasources';
 import { inject } from '@loopback/core';
 import expect from 'expect-runtime';
 import { buildFilterQuery } from '../js/buildFilterQuery';
+import { utils } from '../js/utils';
 
 export class PlanterRepository extends DefaultCrudRepository<
   Planter,
@@ -118,7 +119,8 @@ export class PlanterRepository extends DefaultCrudRepository<
 
         const query = buildFilterQuery(selectStmt, params);
 
-        return <Promise<Planter[]>>await this.execute(query.sql, query.params);
+        const result = await this.execute(query.sql, query.params);
+        return <Planter[]>result.map((planter) => utils.convertCamel(planter));
       } else {
         throw 'Connector not defined';
       }


### PR DESCRIPTION
Resolves #593 

Planter attributes are now returned as expected by the client:
![Screenshot 2021-10-01 at 22 19 00](https://user-images.githubusercontent.com/5558838/135687284-5566a4a3-d524-4a1d-b66f-a7cac3f81657.png)

Also tested with an organization user:
![Screenshot 2021-10-01 at 22 20 43](https://user-images.githubusercontent.com/5558838/135687457-20cd5196-38de-4952-850b-c8de22576bf3.png)

