### PR TITLE
feat(growers): filter growers by deviceIdentifier

### DIFF
--- a/src/controllers/planter.controller.ts
+++ b/src/controllers/planter.controller.ts
@@ -20,8 +20,10 @@ import { Planter, Trees } from '../models';
 import { TreesFilter } from './trees.controller';
 import { PlanterRepository, TreesRepository } from '../repositories';
 
-// Extend the LoopBack filter types for the Planter model to include organizationId
-type PlanterWhere = (Where<Planter> & { organizationId?: number }) | undefined;
+// Extend the LoopBack filter types for the Planter model to include organizationId and deviceIdentifier
+type PlanterWhere =
+  | (Where<Planter> & { deviceIdentifier?: string; organizationId?: number })
+  | undefined;
 export type PlanterFilter = Filter<Planter> & { where: PlanterWhere };
 
 export class PlanterController {
@@ -44,6 +46,8 @@ export class PlanterController {
     @param.query.object('where', getWhereSchemaFor(Planter))
     where?: PlanterWhere,
   ): Promise<Count> {
+    const deviceIdentifier = where?.deviceIdentifier;
+
     // Replace organizationId with full entity tree and planter
     if (where) {
       const { organizationId, ...whereWithoutOrganizationId } = where;
@@ -54,7 +58,7 @@ export class PlanterController {
     }
     // console.log('get /planter/count where -->', where);
 
-    return await this.planterRepository.countWithOrg(where);
+    return await this.planterRepository.countWithOrg(where, deviceIdentifier);
   }
 
   @get('/planter', {
@@ -73,6 +77,8 @@ export class PlanterController {
     @param.query.object('filter', getFilterSchemaFor(Planter))
     filter?: PlanterFilter,
   ): Promise<Planter[]> {
+    const deviceIdentifier = filter?.where?.deviceIdentifier;
+
     // Replace organizationId with full entity tree and planter
     if (filter?.where) {
       const { organizationId, ...whereWithoutOrganizationId } = filter.where;
@@ -82,7 +88,7 @@ export class PlanterController {
       );
     }
 
-    return await this.planterRepository.findWithOrg(filter);
+    return await this.planterRepository.findWithOrg(filter, deviceIdentifier);
   }
 
   @get('/planter/{id}', {

--- a/src/controllers/planterRegistration.controller.ts
+++ b/src/controllers/planterRegistration.controller.ts
@@ -33,9 +33,13 @@ export class PlanterRegistrationController {
 
     const sql = `SELECT * FROM planter_registrations
         LEFT JOIN (
-        SELECT region.name AS country, region.geom FROM region, region_type
-        WHERE region_type.type='country' AND region.type_id=region_type.id
-    ) AS region ON ST_DWithin(region.geom, planter_registrations.geom, 0.01)`;
+          SELECT
+            region.name AS country,
+            region.geom FROM region, region_type
+          WHERE region_type.type='country'
+          AND region.type_id=region_type.id
+        ) AS region
+        ON ST_DWithin(region.geom, planter_registrations.geom, 0.01)`;
 
     const params = {
       filter,

--- a/src/models/planter.model.ts
+++ b/src/models/planter.model.ts
@@ -1,4 +1,5 @@
-import { Entity, model, property } from '@loopback/repository';
+import { Entity, model, property, hasMany } from '@loopback/repository';
+import { PlanterRegistration } from './planterRegistration.model';
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
@@ -182,6 +183,9 @@ export class Planter extends Entity {
     },
   })
   imageRotation?: Number;
+
+  @hasMany(() => PlanterRegistration, { keyTo: 'planterId' })
+  planterRegs: PlanterRegistration[];
 
   // Define well-known properties here
 


### PR DESCRIPTION
## Description
Allow filtering Growers by device identifier

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** 
 - [x] Feature: new filter



## Issue

**What is the current behavior?**

No ability to filter by device_identifier because it is a property on PlanterRegistration table which is not connected to the Planter table.


**What is the new behavior?**

Allow filtering Growers by device identifier by connecting the two repositories on the server so that the client can make requests for filtered information by included the device_identifier value in the filter object.

Steps taken:
 - [x]  Connect PlanterRepository to PlanterRegistrationRepository for queries
 - [x]  Add SQL query to look up device_identifiers and reduce duplicates in answer by grouping them by planter.id
 - [x]  Add "planterRegs" property to PlanterModel as a reference to "planterId" on PlanterRegistrationModel
 - [x]  Add "deviceIdentifier" type to Planter<Where> and Planter<Filter> and to the request handlers
 - [x]  Format query for region on PlanterRegistrationController (no other changes)


## Breaking change
**Does this PR introduce a breaking change?** 
 - [x] No


## Related issues
https://github.com/Greenstand/treetracker-admin-api/issues/458
<img width="919" alt="Growers - Treetracker Admin by Greenstand 2021-10-31 17-18-24" src="https://user-images.githubusercontent.com/1761374/139606208-66892d22-8a2d-4ba4-a04d-01cb97f53382.png">


