### PR TITLE
fix(planters): bugs when filtering by device identifier and org

### DIFF
--- a/src/repositories/planter.repository.ts
+++ b/src/repositories/planter.repository.ts
@@ -77,7 +77,7 @@ export class PlanterRepository extends DefaultCrudRepository<
     if (organizationId === null) {
       const planterIds = await this.getNonOrganizationPlanterIds();
       return {
-        and: [{ organizationId: null }, { id: { inq: planterIds } }],
+        and: [{ organizationId: null }, { 'planter.id': { inq: planterIds } }],
       };
     } else {
       const planterIds = await this.getPlanterIdsByOrganizationId(
@@ -88,7 +88,7 @@ export class PlanterRepository extends DefaultCrudRepository<
       return {
         or: [
           { organizationId: { inq: entityIds } },
-          { id: { inq: planterIds } },
+          { 'planter.id': { inq: planterIds } },
         ],
       };
     }
@@ -113,13 +113,11 @@ export class PlanterRepository extends DefaultCrudRepository<
     if (deviceIdentifier === null) {
       return `LEFT JOIN planter_registrations
         ON planter.id=planter_registrations.planter_id
-        WHERE (planter_registrations.device_identifier ISNULL)
-        GROUP BY planter.id`;
+        WHERE (planter_registrations.device_identifier ISNULL)`;
     }
     return `JOIN planter_registrations
       ON planter.id=planter_registrations.planter_id
-      WHERE (planter_registrations.device_identifier='${deviceIdentifier}')
-      GROUP BY planter.id`;
+      WHERE (planter_registrations.device_identifier='${deviceIdentifier}')`;
   }
 
   // loopback .find() wasn't applying the org filters
@@ -134,10 +132,9 @@ export class PlanterRepository extends DefaultCrudRepository<
 
     try {
       if (this.dataSource.connector) {
-        const columnNames = this.dataSource.connector.buildColumnNames(
-          'Planter',
-          filter,
-        );
+        const columnNames = this.dataSource.connector
+          .buildColumnNames('Planter', filter)
+          .replace('"id"', 'planter.id as "id"');
 
         let selectStmt;
         if (deviceIdentifier) {


### PR DESCRIPTION
## Description
Fix bugs related to filtering Growers by device identifier

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** 
 - [x] Fix: bugs



## Issue

**What is the current behavior?**

The requested count and number of growers retrieved didn't match because are duplicate planter ids that could be grouped for the filter but were still being added to the total count.  Also, when adding an organization id to the search the organization results overrode the device id because the query built couldn't identify what "id" to use.


**What is the new behavior?**

Allow filtering Growers by device identifier and organization.  The count of results will also match the # of growers displayed.

Steps taken:
- [x] Fix bug when org is also filtered
- [x] Remove Group by planter.id from device id query, it reduces duplicates from results but those duplicates still get counted and should be removed via cleaning up the database


## Breaking change
**Does this PR introduce a breaking change?** 
 -  Yes, the client will experience duplicate key errors from React


## Related issues & PRs
https://github.com/Greenstand/treetracker-admin-api/issues/458
