### PR TITLE
feat(grower-detail): display device manufacturer with device id

### DIFF
--- a/src/controllers/planterRegistration.controller.ts
+++ b/src/controllers/planterRegistration.controller.ts
@@ -31,7 +31,8 @@ export class PlanterRegistrationController {
   ): Promise<PlanterRegistration[]> {
     // console.log('/planter-registration', filter ? filter.where : null);
 
-    const sql = `SELECT * FROM planter_registrations
+    const sql = `SELECT planter_registrations.*, devices.manufacturer FROM planter_registrations
+        JOIN devices ON devices.android_id=planter_registrations.device_identifier
         LEFT JOIN (
           SELECT
             region.name AS country,

--- a/src/js/buildFilterQuery.js
+++ b/src/js/buildFilterQuery.js
@@ -47,5 +47,7 @@ export function buildFilterQuery(selectStmt, params) {
     }
   }
 
+  // console.log('QUERY ---------', query);
+
   return query;
 }


### PR DESCRIPTION
## Description
Add device manufacturer to the Planter Registration query

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** 
 - [x] Enhancement



## Issue

**What is the current behavior?**

Only returns info from the planter_registration table at the moment.


**What is the new behavior?**

Adds a join to the devices table to the query so that the device manufacturer info can be retreived.

Steps taken:
 - [x]  Update deviceIdentifier state to include the device OS
 - [x]  Display the device id and the OS on the GrowerDetail component



## Breaking change
**Does this PR introduce a breaking change?** 
 - [x] No
 - [ ] The query for null organizations runs slower than the other queries

## Related PR & Issue
https://github.com/Greenstand/treetracker-admin-client/pull/196
https://github.com/Greenstand/treetracker-admin-api/issues/458
 
 
<img width="926" alt="Growers - Treetracker Admin by Greenstand 2021-11-13 11-15-50" src="https://user-images.githubusercontent.com/1761374/141656439-22354613-9df7-482f-b6ac-73a10dd4f7ae.png">
