### PR TITLE
Fix query for country/region info for GrowerDetail

### DIFF
--- a/src/controllers/planterRegistration.controller.ts
+++ b/src/controllers/planterRegistration.controller.ts
@@ -31,7 +31,7 @@ export class PlanterRegistrationController {
   ): Promise<PlanterRegistration[]> {
     // console.log('/planter-registration', filter ? filter.where : null);
 
-    const sql = `SELECT planter_registrations.*, devices.manufacturer FROM planter_registrations
+    const sql = `SELECT *, devices.manufacturer FROM planter_registrations
         JOIN devices ON devices.android_id=planter_registrations.device_identifier
         LEFT JOIN (
           SELECT


### PR DESCRIPTION
The SQL broke when adding the device-identifier to the query.
Partially Closes: https://github.com/Greenstand/treetracker-admin-client/issues/122

Both device-identifier and country are now working in the query
<img width="938" alt="Growers - Treetracker Admin by Greenstand 2021-11-18 17-51-09" src="https://user-images.githubusercontent.com/1761374/142551196-6b98df30-284e-40aa-8b3a-9d97f2c04d4b.png">
