### PR TITLE
feat: add join clause for trees with any tagid

### DIFF
--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -113,6 +113,8 @@ export class TreesRepository extends DefaultCrudRepository<
   getTreeTagJoinClause(tagId: string): string {
     if (tagId === null) {
       return `LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id ISNULL)`;
+    } else if (tagId === "0") {
+      return `LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id IS NOT NULL)`;
     }
     return `JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id=${tagId})`;
   }

--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -114,7 +114,7 @@ export class TreesRepository extends DefaultCrudRepository<
     if (tagId === null) {
       return `LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id ISNULL)`;
     } else if (tagId === "0") {
-      return `LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id IS NOT NULL)`;
+      return `INNER JOIN tree_tag ON trees.id=tree_tag.tree_id`;
     }
     return `JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id=${tagId})`;
   }


### PR DESCRIPTION
## Description
Added condition to getTreeTagJoinClause for an INNER JOIN on trees and tree_tag when tagId is 0, so that trees can be filtered by all trees with a tag.

**Issue(s) addressed**
- Feature added to allow for resolution of [#199 in treetracker-admin-client](https://github.com/Greenstand/treetracker-admin-client/issues/199)

**What kind of change(s) does this PR introduce?** 
- [x] Enhancement

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

## Issue

**What is the current behavior?**
If the tagId is null getTreeTagJoinClause currently returns all trees that do not have a tree_tag record (`SELECT ... from trees LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id ISNULL)`), otherwise it returns a query for all trees with the tagId specified(`SELECT ... from trees JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id=${tagId})`).

**What is the new behavior?**
Added a condition so that if tagId is "0" (string), then it will return all trees that have a tree tag record (`SELECT ... from trees  INNER JOIN tree_tag ON trees.id=tree_tag.tree_id`).

## Breaking change
**Does this PR introduce a breaking change?** 
No breaking changes.

## Other useful information
