### PR TITLE
fix: add DISTINCT clause to ensure no duplicates

### DIFF
--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -136,7 +136,7 @@ export class TreesRepository extends DefaultCrudRepository<
           .buildColumnNames('Trees', filter)
           .replace('"id"', 'trees.id as "id"');
 
-        const selectStmt = `SELECT ${columnNames} from trees ${this.getTreeTagJoinClause(
+        const selectStmt = `SELECT DISTINCT ${columnNames} from trees ${this.getTreeTagJoinClause(
           tagId,
         )}`;
 
@@ -177,7 +177,7 @@ export class TreesRepository extends DefaultCrudRepository<
     }
 
     try {
-      const selectStmt = `SELECT COUNT(*) FROM trees ${this.getTreeTagJoinClause(
+      const selectStmt = `SELECT COUNT(DISTINCT *) FROM trees ${this.getTreeTagJoinClause(
         tagId,
       )}`;
 

--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -113,6 +113,8 @@ export class TreesRepository extends DefaultCrudRepository<
   getTreeTagJoinClause(tagId: string): string {
     if (tagId === null) {
       return `LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id ISNULL)`;
+    } else if (tagId === "0") {
+      return `LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id IS NOT NULL)`;
     }
     return `JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id=${tagId})`;
   }

--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -114,7 +114,7 @@ export class TreesRepository extends DefaultCrudRepository<
     if (tagId === null) {
       return `LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id ISNULL)`;
     } else if (tagId === "0") {
-      return `LEFT JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id IS NOT NULL)`;
+      return `INNER JOIN tree_tag ON trees.id=tree_tag.tree_id`;
     }
     return `JOIN tree_tag ON trees.id=tree_tag.tree_id WHERE (tree_tag.tag_id=${tagId})`;
   }


### PR DESCRIPTION
Added DISTINCT clause to SQL statements to ensure that trees with more than one tag do not result in duplicate entries.