### PR TITLE
Revert "fix: add DISTINCT clause to ensure no duplicates"

### DIFF
--- a/src/repositories/trees.repository.ts
+++ b/src/repositories/trees.repository.ts
@@ -136,7 +136,7 @@ export class TreesRepository extends DefaultCrudRepository<
           .buildColumnNames('Trees', filter)
           .replace('"id"', 'trees.id as "id"');
 
-        const selectStmt = `SELECT DISTINCT ${columnNames} from trees ${this.getTreeTagJoinClause(
+        const selectStmt = `SELECT ${columnNames} from trees ${this.getTreeTagJoinClause(
           tagId,
         )}`;
 
@@ -177,7 +177,7 @@ export class TreesRepository extends DefaultCrudRepository<
     }
 
     try {
-      const selectStmt = `SELECT COUNT(DISTINCT *) FROM trees ${this.getTreeTagJoinClause(
+      const selectStmt = `SELECT COUNT(*) FROM trees ${this.getTreeTagJoinClause(
         tagId,
       )}`;
 


### PR DESCRIPTION
Reverts Greenstand/treetracker-admin-api#611

Unfortunately, this fix doesn't resolve issue – the inner join on `tree_tag` means that each record is a distinct combination of capture record and tree tag record, so captures with multiple tags are repeated.
Further, the count clause is not working properly and any tag selection returns the same count.