### PR TITLE
Add device manufacturer to planter registration data

### DIFF
--- a/src/controllers/planterOrganization.controller.ts
+++ b/src/controllers/planterOrganization.controller.ts
@@ -6,14 +6,11 @@ import {
   Where,
 } from '@loopback/repository';
 import {
-  // post,
   param,
   get,
   getFilterSchemaFor,
   getWhereSchemaFor,
   patch,
-  // put,
-  // del,
   requestBody,
   HttpErrors,
 } from '@loopback/rest';
@@ -62,9 +59,8 @@ export class PlanterOrganizationController {
       const filterOrgId = organizationId;
 
       if (filterOrgId && filterOrgId !== orgId) {
-        const entityIds = await this.planterRepository.getEntityIdsByOrganizationId(
-          orgId,
-        );
+        const entityIds =
+          await this.planterRepository.getEntityIdsByOrganizationId(orgId);
         orgId = entityIds.includes(filterOrgId) ? filterOrgId : orgId;
       }
 
@@ -103,9 +99,8 @@ export class PlanterOrganizationController {
       const filterOrgId = organizationId;
 
       if (filterOrgId && filterOrgId !== orgId) {
-        const entityIds = await this.planterRepository.getEntityIdsByOrganizationId(
-          orgId,
-        );
+        const entityIds =
+          await this.planterRepository.getEntityIdsByOrganizationId(orgId);
         orgId = entityIds.includes(filterOrgId) ? filterOrgId : orgId;
       }
 
@@ -138,13 +133,16 @@ export class PlanterOrganizationController {
     @param.query.object('filter', getFilterSchemaFor(PlanterRegistration))
     filter?: Filter<PlanterRegistration>,
   ): Promise<PlanterRegistration[]> {
-    // console.log('/organization/{organizationId}/planter-registration');
-
-    const sql = `SELECT * FROM planter_registrations
+    const sql = `SELECT *, devices.manufacturer FROM planter_registrations
+        JOIN devices ON devices.android_id=planter_registrations.device_identifier
         LEFT JOIN (
-        SELECT region.name AS country, region.geom FROM region, region_type
-        WHERE region_type.type='country' AND region.type_id=region_type.id
-    ) AS region ON ST_DWithin(region.geom, planter_registrations.geom, 0.01)`;
+          SELECT
+            region.name AS country,
+            region.geom FROM region, region_type
+          WHERE region_type.type='country'
+          AND region.type_id=region_type.id
+        ) AS region
+        ON ST_DWithin(region.geom, planter_registrations.geom, 0.01)`;
 
     const params = {
       filter,
@@ -221,7 +219,6 @@ export class PlanterOrganizationController {
     @param.query.object('filter', getFilterSchemaFor(Trees))
     filter?: TreesFilter,
   ): Promise<Trees[]> {
-    // console.log('/organization/{organizationId}/planter/{id}/selfies', id, filter);
     filter = {
       where: { planterId: id, planterPhotoUrl: { neq: null } },
       ...filter,

--- a/src/controllers/planterRegistration.controller.ts
+++ b/src/controllers/planterRegistration.controller.ts
@@ -29,8 +29,6 @@ export class PlanterRegistrationController {
     @param.query.object('filter', getFilterSchemaFor(PlanterRegistration))
     filter?: Filter<PlanterRegistration>,
   ): Promise<PlanterRegistration[]> {
-    // console.log('/planter-registration', filter ? filter.where : null);
-
     const sql = `SELECT *, devices.manufacturer FROM planter_registrations
         JOIN devices ON devices.android_id=planter_registrations.device_identifier
         LEFT JOIN (


### PR DESCRIPTION
## Description

Display the device identifiers for both admin and org accounts and make sure there aren't duplicates

**Issue(s) addressed**

- Helps resolve #https://github.com/Greenstand/treetracker-admin-client/issues/146

**What kind of change(s) does this PR introduce?**

- [x] Enhancement
- [x] Bug fix


**Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Comments were added to explain the device manufacturers displayed

## Issue

**What is the current behavior?**
- no query for planter-registration device manufacturers for org account

**What is the new behavior?**
- table join and query added for org accounts

## Other useful information
- This PR relates to an update to the admin-client PR #https://github.com/Greenstand/treetracker-admin-client/pull/279