### PR TITLE
feat: add uuid to species and tag models

### DIFF
--- a/src/models/species.model.ts
+++ b/src/models/species.model.ts
@@ -27,6 +27,20 @@ export class Species extends Entity {
 
   @property({
     type: String,
+    required: true,
+    postgresql: {
+      columnName: 'uuid',
+      dataType: 'varchar',
+      dataLength: null,
+      dataPrecision: null,
+      dataScale: 0,
+      nullable: 'NO',
+    },
+  })
+  uuid: String;
+
+  @property({
+    type: String,
     required: false,
     length: 45,
     postgresql: {

--- a/src/models/tag.model.ts
+++ b/src/models/tag.model.ts
@@ -27,6 +27,20 @@ export class Tag extends Entity {
 
   @property({
     type: String,
+    required: true,
+    postgresql: {
+      columnName: 'uuid',
+      dataType: 'varchar',
+      dataLength: null,
+      dataPrecision: null,
+      dataScale: 0,
+      nullable: 'NO',
+    },
+  })
+  uuid: String;
+
+  @property({
+    type: String,
     required: false,
     postgresql: {
       columnName: 'tag_name',


### PR DESCRIPTION
Add the uuid field to the species and tag models so that we can ease migration to the new microservice tables.